### PR TITLE
Makefile: set LBITS for 32/64 bit build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,15 @@
+
+LBITS := $(shell getconf LONG_BIT)
+
 CFLAGS = -Wall -O3 -I src -msse2 -mfpmath=sse -std=c11 -I include/pcre -D HLDLL_EXPORTS
 LFLAGS = -L. -lhl -ldl
 LIBFLAGS =
 LIBEXT = so
 LIBTURBOJPEG = -lturbojpeg
 
-ifndef ARCH
-ARCH=32
-endif
-
 PCRE = include/pcre/pcre_chartables.o include/pcre/pcre_compile.o include/pcre/pcre_dfa_exec.o \
 	include/pcre/pcre_exec.o include/pcre/pcre_fullinfo.o include/pcre/pcre_globals.o \
-	include/pcre/pcre_newline.o include/pcre/pcre_string_utils.o include/pcre/pcre_tables.o include/pcre/pcre_xclass.o 
+	include/pcre/pcre_newline.o include/pcre/pcre_string_utils.o include/pcre/pcre_tables.o include/pcre/pcre_xclass.o
 
 RUNTIME = src/alloc.o
 
@@ -22,8 +21,8 @@ HL = src/callback.o src/code.o src/jit.o src/main.o src/module.o
 
 FMT = libs/fmt/fmt.o
 
-SDL = libs/sdl/sdl.o libs/sdl/gl.o 
-	
+SDL = libs/sdl/sdl.o libs/sdl/gl.o
+
 LIB = ${PCRE} ${RUNTIME} ${STD}
 
 BOOT = src/hlc_main.o src/_main.o
@@ -36,21 +35,21 @@ ifeq ($(OS),Windows_NT)
 LIBFLAGS += -Wl,--export-all-symbols
 LIBEXT = dll
 
-ifeq ($(ARCH),32)
-CC=i686-pc-cygwin-gcc 
+ifeq ($(LBITS),32)
+CC=i686-pc-cygwin-gcc
 endif
 
 else ifeq ($(UNAME),Darwin)
 
 # Mac
 LIBEXT=dylib
-CFLAGS += -m$(ARCH)
+CFLAGS += -m$(LBITS)
 LFLAGS += -Wl,-export_dynamic
 
 else
 
 # Linux
-CFLAGS += -m$(ARCH) -fPIC
+CFLAGS += -m$(LBITS) -fPIC
 LFLAGS += -lm -Wl,--export-dynamic -Wl,--no-undefined
 
 # otherwise ld will link to the .a and complain about missing -fPIC (Ubuntu 14)
@@ -63,34 +62,32 @@ all: libhl hl libs
 install_lib:
 	cp libhl.${LIBEXT} /usr/local/lib
 
-libs: fmt sdl 
+libs: fmt sdl
 
 libhl: ${LIB}
-	${CC} -o libhl.$(LIBEXT) -m${ARCH} ${LIBFLAGS} -shared ${LIB}
+	${CC} -o libhl.$(LIBEXT) -m${LBITS} ${LIBFLAGS} -shared ${LIB}
 
 hlc: ${BOOT}
 	${CC} ${CFLAGS} -o hlc ${BOOT} ${LFLAGS}
-	
+
 hl: ${HL}
 	${CC} ${CFLAGS} -o hl ${HL} ${LFLAGS}
 
 fmt: ${FMT}
 	${CC} ${CFLAGS} -shared -o fmt.hdll ${FMT} ${LIBFLAGS} -lpng $(LIBTURBOJPEG) -lz
-	
+
 sdl: ${SDL}
 	${CC} ${CFLAGS} -shared -o sdl.hdll ${SDL} ${LIBFLAGS} -lSDL2
-	
+
 .SUFFIXES : .c .o
 
 .c.o :
 	${CC} ${CFLAGS} -o $@ -c $<
-	
+
 clean_o:
 	rm -f ${STD} ${BOOT} ${RUNTIME} ${PCRE} ${HL} ${FMT} ${SDL}
-	
-clean: clean_o 
+
+clean: clean_o
 	rm -f hl hl.exe libhl.$(LIBEXT) *.hdll
 
 .PHONY: libhl hl hlc fmt sdl libs
-
-

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 
 LBITS := $(shell getconf LONG_BIT)
 
+ifndef ARCH
+	ARCH = $(LBITS)
+endif
+
 CFLAGS = -Wall -O3 -I src -msse2 -mfpmath=sse -std=c11 -I include/pcre -D HLDLL_EXPORTS
 LFLAGS = -L. -lhl -ldl
 LIBFLAGS =
@@ -35,7 +39,7 @@ ifeq ($(OS),Windows_NT)
 LIBFLAGS += -Wl,--export-all-symbols
 LIBEXT = dll
 
-ifeq ($(LBITS),32)
+ifeq ($(ARCH),32)
 CC=i686-pc-cygwin-gcc
 endif
 
@@ -43,13 +47,13 @@ else ifeq ($(UNAME),Darwin)
 
 # Mac
 LIBEXT=dylib
-CFLAGS += -m$(LBITS)
+CFLAGS += -m$(ARCH)
 LFLAGS += -Wl,-export_dynamic
 
 else
 
 # Linux
-CFLAGS += -m$(LBITS) -fPIC
+CFLAGS += -m$(ARCH) -fPIC
 LFLAGS += -lm -Wl,--export-dynamic -Wl,--no-undefined
 
 # otherwise ld will link to the .a and complain about missing -fPIC (Ubuntu 14)
@@ -65,12 +69,13 @@ install_lib:
 libs: fmt sdl
 
 libhl: ${LIB}
-	${CC} -o libhl.$(LIBEXT) -m${LBITS} ${LIBFLAGS} -shared ${LIB}
+	${CC} -o libhl.$(LIBEXT) -m${ARCH} ${LIBFLAGS} -shared ${LIB}
 
 hlc: ${BOOT}
 	${CC} ${CFLAGS} -o hlc ${BOOT} ${LFLAGS}
 
 hl: ${HL}
+	echo $(ARCH)
 	${CC} ${CFLAGS} -o hl ${HL} ${LFLAGS}
 
 fmt: ${FMT}


### PR DESCRIPTION
Don't wanna argue over if 32|64 bit should be the default target, but this sets and uses the LBIT flag to determine the system.
NOT tested on mac/win.