### PR TITLE
Small SDL additions

### DIFF
--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -283,6 +283,10 @@ HL_PRIM void HL_NAME(text_input)( bool enable ) {
 		SDL_StopTextInput();
 }
 
+HL_PRIM int HL_NAME(set_relative_mouse_mode)(bool enable) {
+	return SDL_SetRelativeMouseMode(enable);
+}
+
 HL_PRIM vbyte *HL_NAME(detect_keyboard_layout)() {
 	char q = SDL_GetKeyFromScancode(SDL_SCANCODE_Q);
 	char w = SDL_GetKeyFromScancode(SDL_SCANCODE_W);
@@ -306,6 +310,7 @@ DEFINE_PRIM(_VOID, message_box, _BYTES _BYTES _BOOL);
 DEFINE_PRIM(_VOID, set_vsync, _BOOL);
 DEFINE_PRIM(_BOOL, detect_win32, _NO_ARG);
 DEFINE_PRIM(_VOID, text_input, _BOOL);
+DEFINE_PRIM(_I32, set_relative_mouse_mode, _BOOL);
 DEFINE_PRIM(_BYTES, detect_keyboard_layout, _NO_ARG);
 
 // Window

--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -283,6 +283,18 @@ HL_PRIM void HL_NAME(text_input)( bool enable ) {
 		SDL_StopTextInput();
 }
 
+HL_PRIM vbyte *HL_NAME(detect_keyboard_layout)() {
+	char q = SDL_GetKeyFromScancode(SDL_SCANCODE_Q);
+	char w = SDL_GetKeyFromScancode(SDL_SCANCODE_W);
+	char y = SDL_GetKeyFromScancode(SDL_SCANCODE_Y);
+
+	if (q == 'q' && w == 'w' && y == 'y') return "qwerty";
+	if (q == 'a' && w == 'z' && y == 'y') return "azerty";
+	if (q == 'q' && w == 'w' && y == 'z') return "qwertz";
+	if (q == 'q' && w == 'z' && y == 'y') return "qzerty";
+	return "unknown";
+}
+
 DEFINE_PRIM(_BOOL, init_once, _NO_ARG);
 DEFINE_PRIM(_VOID, gl_options, _I32 _I32 _I32 _I32 _I32);
 DEFINE_PRIM(_BOOL, event_loop, _OBJ(_I32 _I32 _I32 _I32 _I32 _I32 _I32 _BOOL _I32 _I32) );
@@ -294,6 +306,7 @@ DEFINE_PRIM(_VOID, message_box, _BYTES _BYTES _BOOL);
 DEFINE_PRIM(_VOID, set_vsync, _BOOL);
 DEFINE_PRIM(_BOOL, detect_win32, _NO_ARG);
 DEFINE_PRIM(_VOID, text_input, _BOOL);
+DEFINE_PRIM(_BYTES, detect_keyboard_layout, _NO_ARG);
 
 // Window
 

--- a/libs/sdl/sdl/Sdl.hx
+++ b/libs/sdl/sdl/Sdl.hx
@@ -55,7 +55,7 @@ class Sdl {
 	static function initOnce() return false;
 	static function eventLoop( e : Event ) return false;
 
-	public static var defaultEventHandler : Event -> Void;
+	public static var defaultEventHandler : Event -> Bool;
 
 	/**
 		Prevent the program from reporting timeout infinite loop.
@@ -69,29 +69,30 @@ class Sdl {
 		while( true ) {
 			if( !eventLoop(event) )
 				break;
-			if( event.type == Quit )
+			var ret = defaultEventHandler(event);
+			if( event.type == Quit && ret )
 				return false;
-			defaultEventHandler(event);
 		}
 		return true;
 	}
 
-	public static function loop( callb : Void -> Void, ?onEvent : Event -> Void ) {
+	public static function loop( callb : Void -> Void, ?onEvent : Event -> Bool ) {
 		var event = new Event();
 		if( onEvent == null ) onEvent = defaultEventHandler;
 		while( true ) {
 			while( true ) {
 				if( !eventLoop(event) )
 					break;
-				if( event.type == Quit )
-					return;
+				var ret = true;
 				if( onEvent != null ) {
 					try {
-						onEvent(event);
+						ret = onEvent(event);
 					} catch( e : Dynamic ) {
 						reportError(e);
 					}
 				}
+				if( event.type == Quit && ret )
+				 	return;
 			}
 			try {
 				callb();

--- a/libs/sdl/sdl/Sdl.hx
+++ b/libs/sdl/sdl/Sdl.hx
@@ -191,6 +191,10 @@ class Sdl {
 		return a;
 	}
 
+	public static function setRelativeMouseMode( enable : Bool ) : Int {
+		return 0;
+	}
+
 	static function detect_keyboard_layout() : hl.Bytes {
 		return null;
 	}

--- a/libs/sdl/sdl/Sdl.hx
+++ b/libs/sdl/sdl/Sdl.hx
@@ -191,4 +191,12 @@ class Sdl {
 		return a;
 	}
 
+	static function detect_keyboard_layout() : hl.Bytes {
+		return null;
+	}
+
+	public static function detectKeyboardLayout(){
+		return @:privateAccess String.fromUTF8(detect_keyboard_layout());
+	}
+
 }


### PR DESCRIPTION
- detectKeyboardLayout() : returns qwerty, azerty, etc.
- setRelativeMouseMode() : locks the mouse in the active window, see : https://wiki.libsdl.org/SDL_SetRelativeMouseMode
- Quit events are now transmitted to the onEvent callback and can be canceled