### PR TITLE
SDL & DirectX additions

### DIFF
--- a/libs/directx/dx/Driver.hx
+++ b/libs/directx/dx/Driver.hx
@@ -700,4 +700,13 @@ class Driver {
 	static function dxDebugPrint( str : hl.Bytes ) {
 	}
 
+	public static function detectKeyboardLayout() @:privateAccess {
+		return String.fromUTF8( dxDetectKeyboardLayout() );
+	}
+
+	@:hlNative("directx", "detect_keyboard_layout")
+	static function dxDetectKeyboardLayout() : hl.Bytes {
+		return null;
+	}
+
 }

--- a/libs/directx/dx/Loop.hx
+++ b/libs/directx/dx/Loop.hx
@@ -5,7 +5,7 @@ class Loop {
 	static var sentinel : hl.UI.Sentinel;
 	static var dismissErrors = false;
 
-	public static var defaultEventHandler : Event -> Void;
+	public static var defaultEventHandler : Event -> Bool;
 
 	/**
 		Prevent the program from reporting timeout infinite loop.
@@ -26,14 +26,14 @@ class Loop {
 		while( true ) {
 			if( !eventLoop(event) )
 				break;
-			if( event.type == Quit )
+			var ret = defaultEventHandler(event);
+			if( event.type == Quit && ret )
 				return false;
-			defaultEventHandler(event);
 		}
 		return true;
 	}
 
-	public static function run( callb : Void -> Void, ?onEvent : Event -> Void ) {
+	public static function run( callb : Void -> Void, ?onEvent : Event -> Bool ) {
 		var event = new Event();
 		if( onEvent == null ) onEvent = defaultEventHandler;
 		while( true ) {
@@ -52,15 +52,16 @@ class Loop {
 			while( true ) {
 				if( !eventLoop(event) )
 					break;
-				if( event.type == Quit )
-					return;
+				var ret = true;
 				if( onEvent != null ) {
 					try {
-						onEvent(event);
+						ret = onEvent(event);
 					} catch( e : Dynamic ) {
 						reportError(e);
 					}
 				}
+				if( event.type == Quit && ret )
+				 	return;
 			}
 			// callback our events handlers
 			try {

--- a/libs/directx/dx/Window.hx
+++ b/libs/directx/dx/Window.hx
@@ -116,6 +116,10 @@ class Window {
 		return winGetNextEvent(win, e);
 	}
 
+	public function clipCursor( enable : Bool ) : Void {
+		winClipCursor(enable ? win : null);
+	}
+
 	static function winCreate( width : Int, height : Int ) : WinPtr {
 		return null;
 	}
@@ -154,6 +158,9 @@ class Window {
 
 	static function winGetNextEvent( win : WinPtr, event : Dynamic ) : Bool {
 		return false;
+	}
+
+	static function winClipCursor( win : WinPtr ) : Void {
 	}
 
 }

--- a/libs/directx/window.c
+++ b/libs/directx/window.c
@@ -357,3 +357,16 @@ DEFINE_PRIM(TCURSOR, create_cursor, _I32 _I32 _BYTES _I32 _I32);
 DEFINE_PRIM(_VOID, destroy_cursor, TCURSOR);
 DEFINE_PRIM(_VOID, set_cursor, TCURSOR);
 DEFINE_PRIM(_VOID, show_cursor, _BOOL);
+
+HL_PRIM vbyte *HL_NAME(detect_keyboard_layout)() {
+	char q = MapVirtualKey(0x10, MAPVK_VSC_TO_VK);
+	char w = MapVirtualKey(0x11, MAPVK_VSC_TO_VK);
+	char y = MapVirtualKey(0x15, MAPVK_VSC_TO_VK);
+
+	if (q == 'Q' && w == 'W' && y == 'Y') return "qwerty";
+	if (q == 'A' && w == 'Z' && y == 'Y') return "azerty";
+	if (q == 'Q' && w == 'W' && y == 'Z') return "qwertz";
+	if (q == 'Q' && w == 'Z' && y == 'Y') return "qzerty";
+	return "unknown";
+}
+DEFINE_PRIM(_BYTES, detect_keyboard_layout, _NO_ARG);

--- a/libs/directx/window.c
+++ b/libs/directx/window.c
@@ -160,6 +160,9 @@ static LRESULT CALLBACK WndProc( HWND wnd, UINT umsg, WPARAM wparam, LPARAM lpar
 	case WM_WINDOWPOSCHANGED:
 		updateClipCursor(wnd);
 		break;
+	case WM_CLOSE:
+		addEvent(wnd, Quit);
+		return 0;
 	}
 	return DefWindowProc(wnd, umsg, wparam, lparam);
 }

--- a/libs/directx/window.c
+++ b/libs/directx/window.c
@@ -61,8 +61,8 @@ static void updateClipCursor(HWND wnd) {
 		RECT rect;
 
 		GetClientRect(wnd, &rect);
-		ClientToScreen(wnd, (LPPOINT)& rect);
-		ClientToScreen(wnd, (LPPOINT)& rect + 1);
+		ClientToScreen(wnd, (LPPOINT)& rect.left);
+		ClientToScreen(wnd, (LPPOINT)& rect.right);
 
 		ClipCursor(&rect);
 	}

--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -70,6 +70,7 @@ typedef struct {
 } event_data;
 
 HL_PRIM bool HL_NAME(init_once)() {
+	SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
 	if (SDL_Init(SDL_INIT_EVERYTHING) != 0)
 		return false;
 #	ifdef _WIN32

--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -71,8 +71,10 @@ typedef struct {
 
 HL_PRIM bool HL_NAME(init_once)() {
 	SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
-	if (SDL_Init(SDL_INIT_EVERYTHING) != 0)
+	if( SDL_Init(SDL_INIT_EVERYTHING) != 0 ) {
+		hl_error_msg(USTR("SDL_Init failed: %s"), hl_to_utf16(SDL_GetError()));
 		return false;
+	}
 #	ifdef _WIN32
 	// Set the internal windows timer period to 1ms (will give accurate sleep for vsync)
 	timeBeginPeriod(1);


### PR DESCRIPTION
- SDL: Allowed joystick background events (when the window has lost focus)
- SDL: init_once now throws an exception on failure (with SDL_GetError message)
- DirectX: Added detect_keyboard_layout and win_clip_cursor
- DirectX: Added handling of window close event