### PR TITLE
SDL/GL: Add backbuffer msaa and some missing enum values

### DIFF
--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -106,7 +106,7 @@ HL_PRIM bool HL_NAME(init_once)() {
 	return true;
 }
 
-HL_PRIM void HL_NAME(gl_options)( int major, int minor, int depth, int stencil, int flags ) {
+HL_PRIM void HL_NAME(gl_options)( int major, int minor, int depth, int stencil, int flags, int samples ) {
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, major);
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, minor);
 	SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, depth);
@@ -120,6 +120,11 @@ HL_PRIM void HL_NAME(gl_options)( int major, int minor, int depth, int stencil, 
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
 	else
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, 0); // auto
+
+	if (samples > 1) {
+		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
+		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, samples);
+	}
 }
 
 HL_PRIM bool HL_NAME(event_loop)( event_data *event ) {
@@ -342,7 +347,7 @@ HL_PRIM const char *HL_NAME(detect_keyboard_layout)() {
 }
 
 DEFINE_PRIM(_BOOL, init_once, _NO_ARG);
-DEFINE_PRIM(_VOID, gl_options, _I32 _I32 _I32 _I32 _I32);
+DEFINE_PRIM(_VOID, gl_options, _I32 _I32 _I32 _I32 _I32 _I32);
 DEFINE_PRIM(_BOOL, event_loop, _OBJ(_I32 _I32 _I32 _I32 _I32 _I32 _I32 _BOOL _I32 _I32 _I32) );
 DEFINE_PRIM(_VOID, quit, _NO_ARG);
 DEFINE_PRIM(_VOID, delay, _I32);

--- a/libs/sdl/sdl/GL.hx
+++ b/libs/sdl/sdl/GL.hx
@@ -441,6 +441,8 @@ class GL {
 	public static inline var POLYGON_OFFSET_FILL            = 0x8037;
 	public static inline var SAMPLE_ALPHA_TO_COVERAGE       = 0x809E;
 	public static inline var SAMPLE_COVERAGE                = 0x80A0;
+	public static inline var MULTISAMPLE                    = 0x809D;
+	public static inline var DEPTH_CLAMP                    = 0x864F;
 
 	/* ErrorCode */
 	public static inline var NO_ERROR                       = 0;
@@ -556,13 +558,14 @@ class GL {
 	public static inline var RGB32F                         = 0x8815;
 	public static inline var RGBA16F                        = 0x881A;
 	public static inline var RGB16F                         = 0x881B;
-
+	public static inline var R11F_G11F_B10F                 = 0x8C3A;
 	public static inline var ALPHA16F                       = 0x881C;
 	public static inline var ALPHA32F                       = 0x8816;
 
 	/* Shaders */
 	public static inline var FRAGMENT_SHADER                  = 0x8B30;
 	public static inline var VERTEX_SHADER                    = 0x8B31;
+	public static inline var GEOMETRY_SHADER                  = 0x8DD9;
 	public static inline var MAX_VERTEX_ATTRIBS               = 0x8869;
 	public static inline var MAX_VERTEX_UNIFORM_VECTORS       = 0x8DFB;
 	public static inline var MAX_VARYING_VECTORS              = 0x8DFC;
@@ -773,7 +776,7 @@ class GL {
 	public static inline var BROWSER_DEFAULT_WEBGL          = 0x9244;
 
 	/* Queries */
-	public static inline var SAMPLES_PASSED					= 0x8914;
-	public static inline var TIMESTAMP						= 0x8E28;
+	public static inline var SAMPLES_PASSED                 = 0x8914;
+	public static inline var TIMESTAMP                      = 0x8E28;
 
 }

--- a/libs/sdl/sdl/Sdl.hx
+++ b/libs/sdl/sdl/Sdl.hx
@@ -16,10 +16,10 @@ class Sdl {
 		isWin32 = detectWin32();
 	}
 
-	public static function setGLOptions( major : Int = 3, minor : Int = 2, depth : Int = 24, stencil : Int = 8, flags : Int = 1 ) {
+	public static function setGLOptions( major : Int = 3, minor : Int = 2, depth : Int = 24, stencil : Int = 8, flags : Int = 1, samples : Int = 1 ) {
 		requiredGLMajor = major;
 		requiredGLMinor = minor;
-		glOptions(major, minor, depth, stencil, flags);
+		glOptions(major, minor, depth, stencil, flags, samples);
 	}
 
 
@@ -38,7 +38,7 @@ class Sdl {
 		Sys.exit( -1);
 	}
 
-	static function glOptions( major : Int, minor : Int, depth : Int, stencil : Int, flags : Int ) {}
+	static function glOptions( major : Int, minor : Int, depth : Int, stencil : Int, flags : Int, samples : Int ) {}
 
 	static function initOnce() return false;
 	static function eventLoop( e : Event ) return false;


### PR DESCRIPTION
Just a few low hanging fruit, nothing particularly interesting.

- new samples option for Sdl.glOptions (does nothing if samples <= 1)
- added GL.DEPTH_CLAMP
- added GL.MULTISAMPLE
- added GL.R11F_G11F_B10F
- added GL.GEOMETRY_SHADER

I've also started on compute, instancing, msaa framebuffers, etc for a later PR.

I've only tested on GL, unsure if these are available on GLES (I think ES 3.2 has all this stuff?)
