### PR TITLE
Use PREFIX variable for INSTALL_PATH if set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
 
 LBITS := $(shell getconf LONG_BIT)
-
-ifndef ARCH
-	ARCH = $(LBITS)
-endif
+ARCH ?= $(LBITS)
+PREFIX ?= /usr/local
+INSTALL_DIR ?= $(PREFIX)
 
 LIBS=fmt sdl ssl openal ui uv
 
@@ -85,9 +84,6 @@ RELEASE_NAME = linux
 
 endif
 
-ifndef INSTALL_DIR
-INSTALL_DIR=/usr/local
-endif
 
 ifdef MESA
 LIBS += mesa


### PR DESCRIPTION
Linux users expect the PREFIX variable respected for the install path.
For a custom install path you still can set INSTALL_PATH which defaults to PREFIX (if set), otherwise /usr/local like before.