### PR TITLE
Add scanCode to SDL and DX keydown/keyup events.

### DIFF
--- a/libs/directx/dx/Event.hx
+++ b/libs/directx/dx/Event.hx
@@ -8,6 +8,7 @@ package dx;
 	public var wheelDelta : Int;
 	public var state : WindowStateChange;
 	public var keyCode : Int;
+	public var scanCode : Int;
 	public var keyRepeat : Bool;
 	public var controller : Int;
 	public var value : Int;

--- a/libs/directx/window.c
+++ b/libs/directx/window.c
@@ -41,6 +41,7 @@ typedef struct {
 	int wheelDelta;
 	WindowStateChange state;
 	int keyCode;
+	int scanCode;
 	bool keyRepeat;
 	int controller;
 	int value;
@@ -160,11 +161,12 @@ static LRESULT CALLBACK WndProc( HWND wnd, UINT umsg, WPARAM wparam, LPARAM lpar
 		// see 
 		e = addEvent(wnd,(umsg == WM_KEYUP || umsg == WM_SYSKEYUP) ? KeyUp : KeyDown);
 		e->keyCode = (int)wparam;
+		e->scanCode = (lparam >> 16) & 0xFF;
 		e->keyRepeat = repeat;
 		// L/R location
 		if( e->keyCode == VK_SHIFT ) {
 			bool right = MapVirtualKey((lparam >> 16) & 0xFF, MAPVK_VSC_TO_VK_EX) == VK_RSHIFT;
-			e->keyCode |= right ? 512 : 256;			
+			e->keyCode |= right ? 512 : 256;
 			e->keyRepeat = false;
 			shift_downs[right?1:0] = e->type == KeyDown;
 		}

--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -75,7 +75,7 @@ typedef struct {
 	int wheelDelta;
 	ws_change state;
 	int keyCode;
-  int scanCode;
+	int scanCode;
 	bool keyRepeat;
 	int controller;
 	int value;

--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -75,6 +75,7 @@ typedef struct {
 	int wheelDelta;
 	ws_change state;
 	int keyCode;
+  int scanCode;
 	bool keyRepeat;
 	int controller;
 	int value;
@@ -147,11 +148,13 @@ HL_PRIM bool HL_NAME(event_loop)( event_data *event ) {
 		case SDL_KEYDOWN:
 			event->type = KeyDown;
 			event->keyCode = e.key.keysym.sym;
+			event->scanCode = e.key.keysym.scancode;
 			event->keyRepeat = e.key.repeat != 0;
 			break;
 		case SDL_KEYUP:
 			event->type = KeyUp;
 			event->keyCode = e.key.keysym.sym;
+			event->scanCode = e.key.keysym.scancode;
 			break;
 		case SDL_SYSWMEVENT:
 			continue;

--- a/libs/sdl/sdl/Event.hx
+++ b/libs/sdl/sdl/Event.hx
@@ -10,6 +10,7 @@ package sdl;
 	public var wheelDelta : Int;
 	public var state : WindowStateChange;
 	public var keyCode : Int;
+	public var scanCode : Int;
 	public var keyRepeat : Bool;
 	public var controller : Int;
 	public var value : Int;


### PR DESCRIPTION
Introduces `Event.scanCode` to both SDL and DirectX on `KeyDown` and `KeyUp` events. 
Reasoning behind that is that `keyCode` acts more like `charCode` and depends on what active keyboard layout user have, making it less consistent.
And since we're not living in PS/2 era and all normal people use USB keyboard, scan codes should be persistent and reliable way that is not reliant on active layout. 

Related: HeapsIO/heaps#492