### PR TITLE
Add resizability configuration and screen centering for DirectX and SDL windows

### DIFF
--- a/libs/directx/dx/Window.hx
+++ b/libs/directx/dx/Window.hx
@@ -18,9 +18,10 @@ class Window {
 
 	static var windows : Array<Window> = [];
 
-	public static inline var CW_USEDEFAULT : Int = 0x80000000;
+	public static inline var CW_USEDEFAULT = 0x80000000;
 
-	public static inline var RESIZABLE : Int = 0x000001;
+	public static inline var HIDDEN    = 0x000001;
+	public static inline var RESIZABLE = 0x000002;
 
 	var win : WinPtr;
 	var savedSize : { x : Int, y : Int, width : Int, height : Int };

--- a/libs/directx/dx/Window.hx
+++ b/libs/directx/dx/Window.hx
@@ -29,8 +29,8 @@ class Window {
 	public var visible(default, set) : Bool = true;
 	public var vsync : Bool;
 
-	public function new( title : String, width : Int, height : Int ) {
-		win = winCreate(width, height);
+	public function new( title : String, width : Int, height : Int, resizable : Bool = true ) {
+		win = winCreateEx(width, height, resizable);
 		this.title = title;
 		windows.push(this);
 		vsync = true;
@@ -76,6 +76,10 @@ class Window {
 
 	public function setPosition( x : Int, y : Int ) {
 		winSetPosition(win, x, y);
+	}
+
+	public function center( centerPrimary : Bool = true ) {
+		winCenter(win, centerPrimary);
 	}
 
 	function get_width() {
@@ -128,6 +132,10 @@ class Window {
 		winClipCursor(enable ? win : null);
 	}
 
+	static function winCreateEx( width : Int, height : Int, resizable : Bool ) : WinPtr {
+		return null;
+	}
+
 	static function winCreate( width : Int, height : Int ) : WinPtr {
 		return null;
 	}
@@ -142,6 +150,9 @@ class Window {
 	}
 
 	static function winSetPosition( win : WinPtr, x : Int, y : Int ) {
+	}
+
+	static function winCenter( win : WinPtr, centerPrimary : Bool ) {
 	}
 
 	static function winResize( win : WinPtr, mode : Int ) {

--- a/libs/directx/dx/Window.hx
+++ b/libs/directx/dx/Window.hx
@@ -18,6 +18,10 @@ class Window {
 
 	static var windows : Array<Window> = [];
 
+	public static inline var CW_USEDEFAULT : Int = 0x80000000;
+
+	public static inline var RESIZABLE : Int = 0x000001;
+
 	var win : WinPtr;
 	var savedSize : { x : Int, y : Int, width : Int, height : Int };
 	public var title(default, set) : String;
@@ -29,8 +33,8 @@ class Window {
 	public var visible(default, set) : Bool = true;
 	public var vsync : Bool;
 
-	public function new( title : String, width : Int, height : Int, resizable : Bool = true ) {
-		win = winCreateEx(width, height, resizable);
+	public function new( title : String, width : Int, height : Int, x : Int = CW_USEDEFAULT, y : Int = CW_USEDEFAULT, windowFlags : Int = RESIZABLE ) {
+		win = winCreateEx(x, y, width, height, windowFlags);
 		this.title = title;
 		windows.push(this);
 		vsync = true;
@@ -132,7 +136,7 @@ class Window {
 		winClipCursor(enable ? win : null);
 	}
 
-	static function winCreateEx( width : Int, height : Int, resizable : Bool ) : WinPtr {
+	static function winCreateEx( x : Int, y : Int, width : Int, height : Int, windowFlags : Int ) : WinPtr {
 		return null;
 	}
 

--- a/libs/directx/window.c
+++ b/libs/directx/window.c
@@ -32,6 +32,10 @@ typedef enum {
 	Close 	= 12
 } WindowStateChange;
 
+typedef enum {
+	Resizable = 0x000001
+} WindowFlags;
+
 typedef struct {
 	hl_type *t;
 	EventType type;
@@ -215,7 +219,7 @@ static LRESULT CALLBACK WndProc( HWND wnd, UINT umsg, WPARAM wparam, LPARAM lpar
 	return DefWindowProc(wnd, umsg, wparam, lparam);
 }
 
-HL_PRIM dx_window *HL_NAME(win_create_ex)( int width, int height, bool resizable ) {
+HL_PRIM dx_window *HL_NAME(win_create_ex)( int x, int y, int width, int height, WindowFlags windowFlags ) {
 	static bool wnd_class_reg = false;
 	HINSTANCE hinst = GetModuleHandle(NULL);
 	if( !wnd_class_reg ) {
@@ -239,8 +243,8 @@ HL_PRIM dx_window *HL_NAME(win_create_ex)( int width, int height, bool resizable
 
 	RECT r;
 	DWORD style = WS_OVERLAPPEDWINDOW | WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
-	if( !resizable )  {
-		style &= ~( WS_MAXIMIZEBOX | WS_THICKFRAME );
+	if( ( windowFlags & Resizable ) == 0 ) {
+		style &= ~(WS_MAXIMIZEBOX | WS_THICKFRAME);
 	}
 	r.left = r.top = 0;
 	r.right = width;
@@ -248,7 +252,7 @@ HL_PRIM dx_window *HL_NAME(win_create_ex)( int width, int height, bool resizable
 	AdjustWindowRect(&r,style,false);
 	dx_events *event_buffer = (dx_events*)malloc(sizeof(dx_events));
 	memset(event_buffer,0, sizeof(dx_events));
-	dx_window *win = CreateWindowEx(WS_EX_APPWINDOW, USTR("HL_WIN"), USTR(""), style, CW_USEDEFAULT, CW_USEDEFAULT, r.right - r.left, r.bottom - r.top, NULL, NULL, hinst, event_buffer);
+	dx_window *win = CreateWindowEx(WS_EX_APPWINDOW, USTR("HL_WIN"), USTR(""), style, x, y, r.right - r.left, r.bottom - r.top, NULL, NULL, hinst, event_buffer);
 	SetTimer(win,0,10,NULL);
 	ShowWindow(win, SW_SHOW);
 	SetCursor(LoadCursor(NULL, IDC_ARROW));
@@ -258,7 +262,7 @@ HL_PRIM dx_window *HL_NAME(win_create_ex)( int width, int height, bool resizable
 }
 
 HL_PRIM dx_window *HL_NAME(win_create)( int width, int height ) {
-	return HL_NAME(win_create_ex)(width, height, true);
+	return HL_NAME(win_create_ex)(CW_USEDEFAULT, CW_USEDEFAULT, width, height, Resizable);
 }
 
 HL_PRIM void HL_NAME(win_set_title)(dx_window *win, vbyte *title) {
@@ -403,7 +407,7 @@ HL_PRIM int HL_NAME(get_screen_height)() {
 }
 
 #define TWIN _ABSTRACT(dx_window)
-DEFINE_PRIM(TWIN, win_create_ex, _I32 _I32 _BOOL);
+DEFINE_PRIM(TWIN, win_create_ex, _I32 _I32 _I32 _I32 _I32);
 DEFINE_PRIM(TWIN, win_create, _I32 _I32);
 DEFINE_PRIM(_VOID, win_set_fullscreen, TWIN _BOOL);
 DEFINE_PRIM(_VOID, win_resize, TWIN _I32);

--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -374,7 +374,7 @@ HL_PRIM SDL_Window *HL_NAME(win_create_ex)(int x, int y, int width, int height, 
 	SDL_GetDesktopDisplayMode(0, &displayMode);
 	w = SDL_CreateWindow("", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_BORDERLESS | sdlFlags);
 #else
-	w = SDL_CreateWindow("", x, y, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | sdlFlags);
+	w = SDL_CreateWindow("", x, y, width, height, SDL_WINDOW_OPENGL | sdlFlags);
 #endif
 #	ifdef HL_WIN
 	// force window to show even if the debugger force process windows to be hidden

--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -366,15 +366,15 @@ DEFINE_PRIM(_BYTES, detect_keyboard_layout, _NO_ARG);
 
 // Window
 
-HL_PRIM SDL_Window *HL_NAME(win_create_ex)(int width, int height, bool resizable) {
+HL_PRIM SDL_Window *HL_NAME(win_create_ex)(int x, int y, int width, int height, int sdlFlags) {
 	SDL_Window *w;
 	// force window to match device resolution on mobile
 #ifdef	HL_MOBILE
 	SDL_DisplayMode displayMode;
 	SDL_GetDesktopDisplayMode(0, &displayMode);
-	w = SDL_CreateWindow("", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_BORDERLESS);
+	w = SDL_CreateWindow("", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_BORDERLESS | sdlFlags);
 #else
-	w = SDL_CreateWindow("", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | (resizable ? SDL_WINDOW_RESIZABLE : 0));
+	w = SDL_CreateWindow("", x, y, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | sdlFlags);
 #endif
 #	ifdef HL_WIN
 	// force window to show even if the debugger force process windows to be hidden
@@ -387,7 +387,7 @@ HL_PRIM SDL_Window *HL_NAME(win_create_ex)(int width, int height, bool resizable
 }
 
 HL_PRIM SDL_Window *HL_NAME(win_create)(int width, int height) {
-	return HL_NAME(win_create_ex)(width, height, false);
+	return HL_NAME(win_create_ex)(SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height, 0);
 }
 
 HL_PRIM SDL_GLContext HL_NAME(win_get_glcontext)(SDL_Window *win) {
@@ -457,10 +457,6 @@ HL_PRIM void HL_NAME(win_get_position)(SDL_Window *win, int *x, int *y) {
 	SDL_GetWindowPosition(win, x, y);
 }
 
-HL_PRIM void HL_NAME(win_center)(SDL_Window *win) {
-	SDL_SetWindowPosition(win, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
-}
-
 HL_PRIM void HL_NAME(win_set_size)(SDL_Window *win, int width, int height) {
 	SDL_SetWindowSize(win, width, height);
 }
@@ -515,7 +511,7 @@ HL_PRIM void HL_NAME(win_destroy)(SDL_Window *win, SDL_GLContext gl) {
 
 #define TWIN _ABSTRACT(sdl_window)
 #define TGL _ABSTRACT(sdl_gl)
-DEFINE_PRIM(TWIN, win_create_ex, _I32 _I32 _BOOL);
+DEFINE_PRIM(TWIN, win_create_ex, _I32 _I32 _I32 _I32 _I32);
 DEFINE_PRIM(TWIN, win_create, _I32 _I32);
 DEFINE_PRIM(TGL, win_get_glcontext, TWIN);
 DEFINE_PRIM(_BOOL, win_set_fullscreen, TWIN _I32);
@@ -523,7 +519,6 @@ DEFINE_PRIM(_VOID, win_resize, TWIN _I32);
 DEFINE_PRIM(_VOID, win_set_title, TWIN _BYTES);
 DEFINE_PRIM(_VOID, win_set_position, TWIN _I32 _I32);
 DEFINE_PRIM(_VOID, win_get_position, TWIN _REF(_I32) _REF(_I32));
-DEFINE_PRIM(_VOID, win_center, TWIN);
 DEFINE_PRIM(_VOID, win_set_size, TWIN _I32 _I32);
 DEFINE_PRIM(_VOID, win_get_size, TWIN _REF(_I32) _REF(_I32));
 DEFINE_PRIM(_VOID, win_swap_window, TWIN);

--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -366,7 +366,7 @@ DEFINE_PRIM(_BYTES, detect_keyboard_layout, _NO_ARG);
 
 // Window
 
-HL_PRIM SDL_Window *HL_NAME(win_create)(int width, int height) {
+HL_PRIM SDL_Window *HL_NAME(win_create_ex)(int width, int height, bool resizable) {
 	SDL_Window *w;
 	// force window to match device resolution on mobile
 #ifdef	HL_MOBILE
@@ -374,7 +374,7 @@ HL_PRIM SDL_Window *HL_NAME(win_create)(int width, int height) {
 	SDL_GetDesktopDisplayMode(0, &displayMode);
 	w = SDL_CreateWindow("", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_BORDERLESS);
 #else
-	w = SDL_CreateWindow("", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
+	w = SDL_CreateWindow("", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | (resizable ? SDL_WINDOW_RESIZABLE : 0));
 #endif
 #	ifdef HL_WIN
 	// force window to show even if the debugger force process windows to be hidden
@@ -384,6 +384,10 @@ HL_PRIM SDL_Window *HL_NAME(win_create)(int width, int height) {
 	}
 #	endif
 	return w;
+}
+
+HL_PRIM SDL_Window *HL_NAME(win_create)(int width, int height) {
+	return HL_NAME(win_create_ex)(width, height, false);
 }
 
 HL_PRIM SDL_GLContext HL_NAME(win_get_glcontext)(SDL_Window *win) {
@@ -445,6 +449,18 @@ HL_PRIM void HL_NAME(win_set_title)(SDL_Window *win, vbyte *title) {
 	SDL_SetWindowTitle(win, (char*)title);
 }
 
+HL_PRIM void HL_NAME(win_set_position)(SDL_Window *win, int x, int y) {
+	SDL_SetWindowPosition(win, x, y);
+}
+
+HL_PRIM void HL_NAME(win_get_position)(SDL_Window *win, int *x, int *y) {
+	SDL_GetWindowPosition(win, x, y);
+}
+
+HL_PRIM void HL_NAME(win_center)(SDL_Window *win) {
+	SDL_SetWindowPosition(win, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+}
+
 HL_PRIM void HL_NAME(win_set_size)(SDL_Window *win, int width, int height) {
 	SDL_SetWindowSize(win, width, height);
 }
@@ -499,11 +515,15 @@ HL_PRIM void HL_NAME(win_destroy)(SDL_Window *win, SDL_GLContext gl) {
 
 #define TWIN _ABSTRACT(sdl_window)
 #define TGL _ABSTRACT(sdl_gl)
+DEFINE_PRIM(TWIN, win_create_ex, _I32 _I32 _BOOL);
 DEFINE_PRIM(TWIN, win_create, _I32 _I32);
 DEFINE_PRIM(TGL, win_get_glcontext, TWIN);
 DEFINE_PRIM(_BOOL, win_set_fullscreen, TWIN _I32);
 DEFINE_PRIM(_VOID, win_resize, TWIN _I32);
 DEFINE_PRIM(_VOID, win_set_title, TWIN _BYTES);
+DEFINE_PRIM(_VOID, win_set_position, TWIN _I32 _I32);
+DEFINE_PRIM(_VOID, win_get_position, TWIN _REF(_I32) _REF(_I32));
+DEFINE_PRIM(_VOID, win_center, TWIN);
 DEFINE_PRIM(_VOID, win_set_size, TWIN _I32 _I32);
 DEFINE_PRIM(_VOID, win_get_size, TWIN _REF(_I32) _REF(_I32));
 DEFINE_PRIM(_VOID, win_swap_window, TWIN);

--- a/libs/sdl/sdl/Window.hx
+++ b/libs/sdl/sdl/Window.hx
@@ -18,8 +18,8 @@ class Window {
 
 	static var windows : Array<Window> = [];
 
-	public static inline var SDL_WINDOWPOS_UNDEFINED : Int = 0x1FFF0000;
-	public static inline var SDL_WINDOWPOS_CENTERED : Int = 0x2FFF0000;
+	public static inline var SDL_WINDOWPOS_UNDEFINED = 0x1FFF0000;
+	public static inline var SDL_WINDOWPOS_CENTERED  = 0x2FFF0000;
 
 	public static inline var SDL_WINDOW_FULLSCREEN         = 0x00000001;
 	public static inline var SDL_WINDOW_OPENGL             = 0x00000002;
@@ -55,7 +55,7 @@ class Window {
 	public var displayMode(default, set) : DisplayMode;
 	public var visible(default, set) : Bool = true;
 
-	public function new( title : String, width : Int, height : Int, x : Int = SDL_WINDOWPOS_CENTERED, y : Int = SDL_WINDOWPOS_CENTERED, sdlFlags : Int = SDL_WINDOW_RESIZABLE ) {
+	public function new( title : String, width : Int, height : Int, x : Int = SDL_WINDOWPOS_CENTERED, y : Int = SDL_WINDOWPOS_CENTERED, sdlFlags : Int = SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE ) {
 		while( true ) {
 			win = winCreateEx(x, y, width, height, sdlFlags);
 			if( win == null ) throw "Failed to create window";

--- a/libs/sdl/sdl/Window.hx
+++ b/libs/sdl/sdl/Window.hx
@@ -25,12 +25,14 @@ class Window {
 	public var vsync(default, set) : Bool;
 	public var width(get, never) : Int;
 	public var height(get, never) : Int;
+	public var x(get, never) : Int;
+	public var y(get, never) : Int;
 	public var displayMode(default, set) : DisplayMode;
 	public var visible(default, set) : Bool = true;
 
-	public function new( title : String, width : Int, height : Int ) {
+	public function new( title : String, width : Int, height : Int, resizable : Bool = true ) {
 		while( true ) {
-			win = winCreate(width, height);
+			win = winCreateEx(width, height, resizable);
 			if( win == null ) throw "Failed to create window";
 			glctx = winGetGLContext(win);
 			if( glctx == null || !GL.init() || !testGL() ) {
@@ -122,6 +124,14 @@ class Window {
 		winSetSize(win, width, height);
 	}
 
+	public function setPosition( x : Int, y : Int ) {
+		winSetPosition(win, x, y);
+	}
+
+	public function center() {
+		winCenter(win);
+	}
+
 	function get_width() {
 		var w = 0;
 		winGetSize(win, w, null);
@@ -132,6 +142,18 @@ class Window {
 		var h = 0;
 		winGetSize(win, null, h);
 		return h;
+	}
+
+	function get_x() {
+		var x = 0;
+		winGetPosition(win, x, null);
+		return x;
+	}
+
+	function get_y() {
+		var y = 0;
+		winGetPosition(win, null, y);
+		return y;
 	}
 
 	function set_vsync(v) {
@@ -176,11 +198,24 @@ class Window {
 		winResize(win, 2);
 	}
 
+	static function winCreateEx( width : Int, height : Int, resizable : Bool ) : WinPtr {
+		return null;
+	}
+
 	static function winCreate( width : Int, height : Int ) : WinPtr {
 		return null;
 	}
 
 	static function winSetTitle( win : WinPtr, title : hl.Bytes ) {
+	}
+
+	static function winSetPosition( win : WinPtr, width : Int, height : Int ) {
+	}
+
+	static function winGetPosition( win : WinPtr, width : hl.Ref<Int>, height : hl.Ref<Int> ) {
+	}
+
+	static function winCenter( win : WinPtr ) {
 	}
 
 	static function winGetGLContext( win : WinPtr ) : GLContext {

--- a/libs/sdl/sdl/Window.hx
+++ b/libs/sdl/sdl/Window.hx
@@ -18,6 +18,31 @@ class Window {
 
 	static var windows : Array<Window> = [];
 
+	public static inline var SDL_WINDOWPOS_UNDEFINED : Int = 0x1FFF0000;
+	public static inline var SDL_WINDOWPOS_CENTERED : Int = 0x2FFF0000;
+
+	public static inline var SDL_WINDOW_FULLSCREEN         = 0x00000001;
+	public static inline var SDL_WINDOW_OPENGL             = 0x00000002;
+	public static inline var SDL_WINDOW_SHOWN              = 0x00000004;
+	public static inline var SDL_WINDOW_HIDDEN             = 0x00000008;
+	public static inline var SDL_WINDOW_BORDERLESS         = 0x00000010;
+	public static inline var SDL_WINDOW_RESIZABLE          = 0x00000020;
+	public static inline var SDL_WINDOW_MINIMIZED          = 0x00000040;
+	public static inline var SDL_WINDOW_MAXIMIZED          = 0x00000080;
+	public static inline var SDL_WINDOW_INPUT_GRABBED      = 0x00000100;
+	public static inline var SDL_WINDOW_INPUT_FOCUS        = 0x00000200;
+	public static inline var SDL_WINDOW_MOUSE_FOCUS        = 0x00000400;
+	public static inline var SDL_WINDOW_FULLSCREEN_DESKTOP = 0x00001001;
+	public static inline var SDL_WINDOW_FOREIGN            = 0x00000800;
+	public static inline var SDL_WINDOW_ALLOW_HIGHDPI      = 0x00002000;
+	public static inline var SDL_WINDOW_MOUSE_CAPTURE      = 0x00004000;
+	public static inline var SDL_WINDOW_ALWAYS_ON_TOP      = 0x00008000;
+	public static inline var SDL_WINDOW_SKIP_TASKBAR       = 0x00010000;
+	public static inline var SDL_WINDOW_UTILITY            = 0x00020000;
+	public static inline var SDL_WINDOW_TOOLTIP            = 0x00040000;
+	public static inline var SDL_WINDOW_POPUP_MENU         = 0x00080000;
+	public static inline var SDL_WINDOW_VULKAN             = 0x10000000;
+
 	var win : WinPtr;
 	var glctx : GLContext;
 	var lastFrame : Float;
@@ -30,9 +55,9 @@ class Window {
 	public var displayMode(default, set) : DisplayMode;
 	public var visible(default, set) : Bool = true;
 
-	public function new( title : String, width : Int, height : Int, resizable : Bool = true ) {
+	public function new( title : String, width : Int, height : Int, x : Int = SDL_WINDOWPOS_CENTERED, y : Int = SDL_WINDOWPOS_CENTERED, sdlFlags : Int = SDL_WINDOW_RESIZABLE ) {
 		while( true ) {
-			win = winCreateEx(width, height, resizable);
+			win = winCreateEx(x, y, width, height, sdlFlags);
 			if( win == null ) throw "Failed to create window";
 			glctx = winGetGLContext(win);
 			if( glctx == null || !GL.init() || !testGL() ) {
@@ -129,7 +154,7 @@ class Window {
 	}
 
 	public function center() {
-		winCenter(win);
+		setPosition(SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 	}
 
 	function get_width() {
@@ -198,7 +223,7 @@ class Window {
 		winResize(win, 2);
 	}
 
-	static function winCreateEx( width : Int, height : Int, resizable : Bool ) : WinPtr {
+	static function winCreateEx( x : Int, y : Int, width : Int, height : Int, sdlFlags : Int ) : WinPtr {
 		return null;
 	}
 
@@ -213,9 +238,6 @@ class Window {
 	}
 
 	static function winGetPosition( win : WinPtr, width : hl.Ref<Int>, height : hl.Ref<Int> ) {
-	}
-
-	static function winCenter( win : WinPtr ) {
 	}
 
 	static function winGetGLContext( win : WinPtr ) : GLContext {


### PR DESCRIPTION
I wanted to provide some additional options to my own HashLink window in Heaps, so I went ahead and added a couple extra things to both window implementations. Figured they may be worth a pull request here.

_**Original Synopsis**_
The option to enable user resizing of the window can be enabled or disabled upon initialization (through constructor parameters) for both DirectX and SDL windows. A new method was created for the C bindings in order to maintain compatibility.

SDL was provided with position getters and a position setter method to match DirectX's implementation. Furthermore, both window implementations were provided with a method to center the window to the screen.