### PR TITLE
Fix HL_IOS define

### DIFF
--- a/src/hl.h
+++ b/src/hl.h
@@ -224,20 +224,13 @@ HL_API int uvszprintf( uchar *out, int out_size, const uchar *fmt, va_list argli
 #	define utoi(s,end)	wcstol(s,end,10)
 #	define ucmp(a,b)	wcscmp(a,b)
 #	define utostr(out,size,str) wcstombs(out,str,size)
-#elif defined(HL_MAC)
+#elif defined(HL_MAC) || defined(HL_IOS) || defined(HL_TVOS)
 typedef uint16_t uchar;
 #	undef USTR
 #	define USTR(str)	u##str
 #else
 #	include <stdarg.h>
-#if defined(HL_IOS) || defined(HL_TVOS) || defined(HL_MAC)
-#include <stddef.h>
-#include <stdint.h>
-typedef uint16_t char16_t;
-typedef uint32_t char32_t;
-#else
 #	include <uchar.h>
-#endif
 typedef char16_t uchar;
 #	undef USTR
 #	define USTR(str)	u##str


### PR DESCRIPTION
Hello,

In order to compile for iOS I needed to slightly change the defines. I am not sure how valid this fix is. Maybe the `HL_IOS` define got outdated? Maybe I am missing something in the build process?

Compiling with Xcode Version 10.1 (10B61). Original build error was:
`/hl/src/hl.h:236:18: Cannot combine with previous 'type-name' declaration specifier`