### PR TITLE
Fixed DirectX Cursor

### DIFF
--- a/libs/directx/dx/Cursor.hx
+++ b/libs/directx/dx/Cursor.hx
@@ -37,6 +37,11 @@ abstract Cursor(CursorPtr) {
 	public static function show( v : Bool ) {
 	}
 
+	@:hlNative("directx","is_cursor_visible")
+	public static function isVisible() : Bool {
+		return false;
+	}
+
 	@:hlNative("directx","set_cursor")
 	static function setCursor( k : CursorPtr ) {
 	}

--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -609,6 +609,10 @@ HL_PRIM void HL_NAME(show_cursor)( bool b ) {
 	SDL_ShowCursor(b?SDL_ENABLE:SDL_DISABLE);
 }
 
+HL_PRIM bool HL_NAME(is_cursor_visible)() {
+	return SDL_ShowCursor(SDL_QUERY) == SDL_ENABLE;
+}
+
 HL_PRIM SDL_Cursor *HL_NAME(cursor_create)( SDL_Surface *s, int hotX, int hotY ) {
 	return SDL_CreateColorCursor(s,hotX,hotY);
 }
@@ -642,6 +646,7 @@ HL_PRIM varray *HL_NAME(get_devices)() {
 
 #define _CURSOR _ABSTRACT(sdl_cursor)
 DEFINE_PRIM(_VOID, show_cursor, _BOOL);
+DEFINE_PRIM(_BOOL, is_cursor_visible, _NO_ARG);
 DEFINE_PRIM(_CURSOR, cursor_create, _SURF _I32 _I32);
 DEFINE_PRIM(_CURSOR, cursor_create_system, _I32);
 DEFINE_PRIM(_VOID, free_cursor, _CURSOR);

--- a/libs/sdl/sdl/Cursor.hx
+++ b/libs/sdl/sdl/Cursor.hx
@@ -43,6 +43,11 @@ abstract Cursor(CursorPtr) {
 	public static function show( v : Bool ) {
 	}
 
+	@:hlNative("sdl", "is_cursor_visible")
+	public static function isVisible() : Bool {
+		return false;
+	}
+
 	@:hlNative("sdl", "set_cursor")
 	static function setCursor( k : CursorPtr ) {
 	}


### PR DESCRIPTION
At the current moment, the DirectX's cursor implementation is completely broken. The cursor only changes for a bit, but reverts back immediately since the WM_SETCURSOR event is not handled. Another issue is that "hiding" the cursor doesn't just hide it in the client area, but the entire application including the title bar (making it difficult to move, close, etc.).

This pull request fixes both issues and also adds a method for checking cursor visibility on both DX and SDL.