### PR TITLE
Add Minimum/Maximum Size and Opacity Configuration for Windows

### DIFF
--- a/libs/directx/dx/Window.hx
+++ b/libs/directx/dx/Window.hx
@@ -36,6 +36,7 @@ class Window {
 	public var y(get, never) : Int;
 	public var displayMode(default, set) : DisplayMode;
 	public var visible(default, set) : Bool = true;
+	public var opacity(get, set) : Float;
 	public var vsync : Bool;
 
 	public function new( title : String, width : Int, height : Int, x : Int = CW_USEDEFAULT, y : Int = CW_USEDEFAULT, windowFlags : Int = RESIZABLE ) {

--- a/libs/directx/dx/Window.hx
+++ b/libs/directx/dx/Window.hx
@@ -28,6 +28,10 @@ class Window {
 	public var title(default, set) : String;
 	public var width(get, never) : Int;
 	public var height(get, never) : Int;
+	public var minWidth(get, never) : Int;
+	public var minHeight(get, never) : Int;
+	public var maxWidth(get, never) : Int;
+	public var maxHeight(get, never) : Int;
 	public var x(get, never) : Int;
 	public var y(get, never) : Int;
 	public var displayMode(default, set) : DisplayMode;
@@ -79,6 +83,14 @@ class Window {
 		winSetSize(win, width, height);
 	}
 
+	public function setMinSize( width : Int, height : Int ) {
+		winSetMinSize(win, width, height);
+	}
+
+	public function setMaxSize( width : Int, height : Int ) {
+		winSetMaxSize(win, width, height);
+	}
+
 	public function setPosition( x : Int, y : Int ) {
 		winSetPosition(win, x, y);
 	}
@@ -99,6 +111,30 @@ class Window {
 		return h;
 	}
 
+	function get_minWidth() {
+		var w = 0;
+		winGetMinSize(win, w, null);
+		return w;
+	}
+
+	function get_minHeight() {
+		var h = 0;
+		winGetMinSize(win, null, h);
+		return h;
+	}
+
+	function get_maxWidth() {
+		var w = 0;
+		winGetMaxSize(win, w, null);
+		return w;
+	}
+
+	function get_maxHeight() {
+		var h = 0;
+		winGetMaxSize(win, null, h);
+		return h;
+	}
+
 	function get_x() {
 		var x = 0;
 		winGetPosition(win, x, null);
@@ -109,6 +145,15 @@ class Window {
 		var y = 0;
 		winGetPosition(win, null, y);
 		return y;
+	}
+
+	function get_opacity() {
+		return winGetOpacity(win);
+	}
+
+	function set_opacity(v) {
+		winSetOpacity(win, v);
+		return v;
 	}
 
 	public function destroy() {
@@ -154,6 +199,12 @@ class Window {
 	static function winSetSize( win : WinPtr, width : Int, height : Int ) {
 	}
 
+	static function winSetMinSize( win : WinPtr, width : Int, height : Int ) {
+	}
+
+	static function winSetMaxSize( win : WinPtr, width : Int, height : Int ) {
+	}
+
 	static function winSetPosition( win : WinPtr, x : Int, y : Int ) {
 	}
 
@@ -166,7 +217,21 @@ class Window {
 	static function winGetSize( win : WinPtr, width : hl.Ref<Int>, height : hl.Ref<Int> ) {
 	}
 
+	static function winGetMinSize( win : WinPtr, width : hl.Ref<Int>, height : hl.Ref<Int> ) {
+	}
+
+	static function winGetMaxSize( win : WinPtr, width : hl.Ref<Int>, height : hl.Ref<Int> ) {
+	}
+
 	static function winGetPosition( win : WinPtr, x : hl.Ref<Int>, y : hl.Ref<Int> ) {
+	}
+
+	static function winGetOpacity( win : WinPtr ) : Float {
+		return 0.0;
+	}
+
+	static function winSetOpacity( win : WinPtr, opacity : Float ) : Bool {
+		return false;
 	}
 
 	static function winDestroy( win : WinPtr ) {

--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -461,8 +461,34 @@ HL_PRIM void HL_NAME(win_set_size)(SDL_Window *win, int width, int height) {
 	SDL_SetWindowSize(win, width, height);
 }
 
+HL_PRIM void HL_NAME(win_set_min_size)(SDL_Window *win, int width, int height) {
+	SDL_SetWindowMinimumSize(win, width, height);
+}
+
+HL_PRIM void HL_NAME(win_set_max_size)(SDL_Window *win, int width, int height) {
+	SDL_SetWindowMaximumSize(win, width, height);
+}
+
 HL_PRIM void HL_NAME(win_get_size)(SDL_Window *win, int *width, int *height) {
 	SDL_GetWindowSize(win, width, height);
+}
+
+HL_PRIM void HL_NAME(win_get_min_size)(SDL_Window *win, int *width, int *height) {
+	SDL_GetWindowMinimumSize(win, width, height);
+}
+
+HL_PRIM void HL_NAME(win_get_max_size)(SDL_Window *win, int *width, int *height) {
+	SDL_GetWindowMaximumSize(win, width, height);
+}
+
+HL_PRIM double HL_NAME(win_get_opacity)(SDL_Window *win) {
+	float opacity = 1.0f;
+	SDL_GetWindowOpacity(win, &opacity);
+	return opacity;
+}
+
+HL_PRIM bool HL_NAME(win_set_opacity)(SDL_Window *win, double opacity) {
+	return SDL_SetWindowOpacity(win, opacity) == 0;
 }
 
 HL_PRIM void HL_NAME(win_resize)(SDL_Window *win, int mode) {
@@ -520,7 +546,13 @@ DEFINE_PRIM(_VOID, win_set_title, TWIN _BYTES);
 DEFINE_PRIM(_VOID, win_set_position, TWIN _I32 _I32);
 DEFINE_PRIM(_VOID, win_get_position, TWIN _REF(_I32) _REF(_I32));
 DEFINE_PRIM(_VOID, win_set_size, TWIN _I32 _I32);
+DEFINE_PRIM(_VOID, win_set_min_size, TWIN _I32 _I32);
+DEFINE_PRIM(_VOID, win_set_max_size, TWIN _I32 _I32);
 DEFINE_PRIM(_VOID, win_get_size, TWIN _REF(_I32) _REF(_I32));
+DEFINE_PRIM(_VOID, win_get_min_size, TWIN _REF(_I32) _REF(_I32));
+DEFINE_PRIM(_VOID, win_get_max_size, TWIN _REF(_I32) _REF(_I32));
+DEFINE_PRIM(_F64, win_get_opacity, TWIN);
+DEFINE_PRIM(_BOOL, win_set_opacity, TWIN _F64);
 DEFINE_PRIM(_VOID, win_swap_window, TWIN);
 DEFINE_PRIM(_VOID, win_render_to, TWIN TGL);
 DEFINE_PRIM(_VOID, win_destroy, TWIN TGL);

--- a/libs/sdl/sdl/Window.hx
+++ b/libs/sdl/sdl/Window.hx
@@ -50,10 +50,15 @@ class Window {
 	public var vsync(default, set) : Bool;
 	public var width(get, never) : Int;
 	public var height(get, never) : Int;
+	public var minWidth(get, never) : Int;
+	public var minHeight(get, never) : Int;
+	public var maxWidth(get, never) : Int;
+	public var maxHeight(get, never) : Int;
 	public var x(get, never) : Int;
 	public var y(get, never) : Int;
 	public var displayMode(default, set) : DisplayMode;
 	public var visible(default, set) : Bool = true;
+	public var opacity(get, set) : Float;
 
 	public function new( title : String, width : Int, height : Int, x : Int = SDL_WINDOWPOS_CENTERED, y : Int = SDL_WINDOWPOS_CENTERED, sdlFlags : Int = SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE ) {
 		while( true ) {
@@ -149,6 +154,14 @@ class Window {
 		winSetSize(win, width, height);
 	}
 
+	public function setMinSize( width : Int, height : Int ) {
+		winSetMinSize(win, width, height);
+	}
+
+	public function setMaxSize( width : Int, height : Int ) {
+		winSetMaxSize(win, width, height);
+	}
+
 	public function setPosition( x : Int, y : Int ) {
 		winSetPosition(win, x, y);
 	}
@@ -169,6 +182,30 @@ class Window {
 		return h;
 	}
 
+	function get_minWidth() {
+		var w = 0;
+		winGetMinSize(win, w, null);
+		return w;
+	}
+
+	function get_minHeight() {
+		var h = 0;
+		winGetMinSize(win, null, h);
+		return h;
+	}
+
+	function get_maxWidth() {
+		var w = 0;
+		winGetMaxSize(win, w, null);
+		return w;
+	}
+
+	function get_maxHeight() {
+		var h = 0;
+		winGetMaxSize(win, null, h);
+		return h;
+	}
+
 	function get_x() {
 		var x = 0;
 		winGetPosition(win, x, null);
@@ -184,6 +221,15 @@ class Window {
 	function set_vsync(v) {
 		setVsync(v);
 		return vsync = v;
+	}
+
+	function get_opacity() {
+		return winGetOpacity(win);
+	}
+
+	function set_opacity(v) {
+		winSetOpacity(win, v);
+		return v;
 	}
 
 	/**
@@ -257,7 +303,27 @@ class Window {
 	static function winResize( win : WinPtr, mode : Int ) {
 	}
 
+	static function winSetMinSize( win : WinPtr, width : Int, height : Int ) {
+	}
+
+	static function winSetMaxSize( win : WinPtr, width : Int, height : Int ) {
+	}
+
 	static function winGetSize( win : WinPtr, width : hl.Ref<Int>, height : hl.Ref<Int> ) {
+	}
+
+	static function winGetMinSize( win : WinPtr, width : hl.Ref<Int>, height : hl.Ref<Int> ) {
+	}
+
+	static function winGetMaxSize( win : WinPtr, width : hl.Ref<Int>, height : hl.Ref<Int> ) {
+	}
+
+	static function winGetOpacity( win : WinPtr ) : Float {
+		return 0.0;
+	}
+
+	static function winSetOpacity( win : WinPtr, opacity : Float ) : Bool {
+		return false;
 	}
 
 	static function winRenderTo( win : WinPtr, gl : GLContext ) {


### PR DESCRIPTION
I've exposed SDL's functions for optionally providing a minimum and maximum size for windows along with the ability to set a window's opacity. These features have also been ported over to the DirectX implementation; as usual, they are based off of SDL's in order to provide consistency. 