### PR TITLE
Fix macos warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ else ifeq ($(UNAME),Darwin)
 
 # Mac
 LIBEXT=dylib
-CFLAGS += -m$(ARCH) -I /opt/libjpeg-turbo/include -I /usr/local/opt/jpeg-turbo/include -I /usr/local/include -I /usr/local/opt/libvorbis/include -I /usr/local/opt/openal-soft/include -Dopenal_soft
+CFLAGS += -m$(ARCH) -I /opt/libjpeg-turbo/include -I /usr/local/opt/jpeg-turbo/include -I /usr/local/include -I /usr/local/opt/libvorbis/include -I /usr/local/opt/openal-soft/include -Dopenal_soft  -DGL_SILENCE_DEPRECATION
 LFLAGS += -Wl,-export_dynamic -L/usr/local/lib
 LIBFLAGS += -L/opt/libjpeg-turbo/lib -L/usr/local/opt/jpeg-turbo/lib -L/usr/local/lib -L/usr/local/opt/libvorbis/lib -L/usr/local/opt/openal-soft/lib
 LIBOPENGL = -framework OpenGL

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -1204,7 +1204,7 @@ static void *gc_alloc_page_memory( int size ) {
 #elif defined(HL_CONSOLE)
 	return sys_alloc_align(size, GC_PAGE_SIZE);
 #else
-	int i;
+	int i = 0;
 	while( gc_will_collide(base_addr,size) ) {
 		base_addr = (char*)base_addr + GC_PAGE_SIZE;
 		i++;

--- a/src/main.c
+++ b/src/main.c
@@ -110,7 +110,7 @@ __declspec(dllexport) DWORD NvOptimusEnablement = 1;
 __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
 #endif
 
-#if defined(HL_LINUX) || defined(HL_OSX)
+#if defined(HL_LINUX) || defined(HL_MAC)
 #include <signal.h>
 static void handle_signal( int signum ) {
 	signal(signum, SIG_DFL);

--- a/src/std/thread.c
+++ b/src/std/thread.c
@@ -365,6 +365,10 @@ HL_PRIM int hl_thread_id() {
 	return 0;
 #elif defined(HL_WIN)
 	return (int)GetCurrentThreadId();
+#elif defined(HL_MAC)
+	uint64_t tid64;
+	pthread_threadid_np(NULL, &tid64);
+	return (pid_t)tid64;
 #elif defined(SYS_gettid) && !defined(HL_TVOS)
 	return syscall(SYS_gettid);
 #else


### PR DESCRIPTION
Fix for deprecated `syscall(SYS_getid)` comes from here:
https://github.com/PowerShell/PowerShell/pull/2675/files

Is there some test I can do to verify this is working correctly? Also suspect return type (uint64) is an issue – bear in mind I know nothing about C programming, just trying to help ;)