### PR TITLE
Allow use of libhl.so in the same directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ else
 
 # Linux
 CFLAGS += -m$(ARCH) -fPIC -pthread
-LFLAGS += -lm -Wl,--export-dynamic -Wl,--no-undefined
+LFLAGS += -lm -Wl,-rpath,. -Wl,--export-dynamic -Wl,--no-undefined
 
 ifeq ($(ARCH),32)
 CFLAGS += -I /usr/include/i386-linux-gnu


### PR DESCRIPTION
This change allows the use of `hl` locally on Linux without it being installed to the system

```
make libhl
make hl
./hl
```