### PR TITLE
Let macOS build set the SDK version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,13 @@ else ifeq ($(UNAME),Darwin)
 LIBEXT=dylib
 CFLAGS += -m$(ARCH) -I /opt/libjpeg-turbo/include -I /usr/local/opt/jpeg-turbo/include -I /usr/local/include -I /usr/local/opt/libvorbis/include -I /usr/local/opt/openal-soft/include -Dopenal_soft  -DGL_SILENCE_DEPRECATION
 LFLAGS += -Wl,-export_dynamic -L/usr/local/lib
+
+ifneq ($(origin SDK), undefined)
+ISYSROOT = $(shell xcrun --sdk macosx$(SDK) --show-sdk-path)
+CFLAGS += -isysroot $(ISYSROOT)
+LFLAGS += -isysroot $(ISYSROOT)
+endif
+
 LIBFLAGS += -L/opt/libjpeg-turbo/lib -L/usr/local/opt/jpeg-turbo/lib -L/usr/local/lib -L/usr/local/opt/libvorbis/lib -L/usr/local/opt/openal-soft/lib
 LIBOPENGL = -framework OpenGL
 LIBOPENAL = -lopenal

--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,8 @@ LIBEXT=dylib
 CFLAGS += -m$(ARCH) -I /opt/libjpeg-turbo/include -I /usr/local/opt/jpeg-turbo/include -I /usr/local/include -I /usr/local/opt/libvorbis/include -I /usr/local/opt/openal-soft/include -Dopenal_soft  -DGL_SILENCE_DEPRECATION
 LFLAGS += -Wl,-export_dynamic -L/usr/local/lib
 
-ifneq ($(origin SDK), undefined)
-ISYSROOT = $(shell xcrun --sdk macosx$(SDK) --show-sdk-path)
+ifneq ($(origin OSX_SDK), undefined)
+ISYSROOT = $(shell xcrun --sdk macosx$(OSX_SDK) --show-sdk-path)
 CFLAGS += -isysroot $(ISYSROOT)
 LFLAGS += -isysroot $(ISYSROOT)
 endif

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ LIBEXT=dylib
 CFLAGS += -m$(ARCH) -I /opt/libjpeg-turbo/include -I /usr/local/opt/jpeg-turbo/include -I /usr/local/include -I /usr/local/opt/libvorbis/include -I /usr/local/opt/openal-soft/include -Dopenal_soft  -DGL_SILENCE_DEPRECATION
 LFLAGS += -Wl,-export_dynamic -L/usr/local/lib
 
-ifneq ($(origin OSX_SDK), undefined)
+ifdef OSX_SDK
 ISYSROOT = $(shell xcrun --sdk macosx$(OSX_SDK) --show-sdk-path)
 CFLAGS += -isysroot $(ISYSROOT)
 LFLAGS += -isysroot $(ISYSROOT)


### PR DESCRIPTION
This change allows for the developer to specify a macOS SDK version. This is important in order to build HashLink for older macOS systems, while building on a newer system.

I debated whether this should have a different variable name (such as `SDK_VERSION`), but thought SDK would be easier to remember, and more convenient if you do not have to try and find the full SDK path yourself

```
make SDK=10.14
```