### PR TITLE
Unicode fixes

### DIFF
--- a/src/std/string.c
+++ b/src/std/string.c
@@ -225,7 +225,7 @@ HL_PRIM vbyte *hl_utf16_to_utf8( vbyte *str, int len, int *size ) {
 			out[p++] = (vbyte)(0xC0|(v>>6));
 			out[p++] = (vbyte)(0x80|(v&63));
 		} else if( v >= 0xD800 && v <= 0xDFFF ) {
-			int k = ((((int)v - 0xD800) << 10) | (((int)*++c) - 0xDC00)) + 0x10000;
+			int k = ((((int)v - 0xD800) << 10) | (((int)*++c) - 0xDC00));
 			out[p++] = (vbyte)(0xF0|(k>>18));
 			out[p++] = (vbyte)(0x80 | ((k >> 12) & 63));
 			out[p++] = (vbyte)(0x80 | ((k >> 6) & 63));
@@ -272,7 +272,7 @@ HL_PRIM vbyte *hl_url_encode( vbyte *str, int *len ) {
 				sur = (unsigned)*cstr;
 				if( sur >= 0xDC00 && sur < 0xDFFF ) {
 					cstr++;
-					c = ((((int)c - 0xD800) << 10) | ((int)sur - 0xDC00)) + 0x10000;
+					c = ((((int)c - 0xD800) << 10) | ((int)sur - 0xDC00));
 					hl_buffer_hex(b, 0xF0|(c>>18));
 					hl_buffer_hex(b, 0x80|((c >> 12) & 63));
 					hl_buffer_hex(b, 0x80|((c >> 6) & 63));

--- a/src/std/string.c
+++ b/src/std/string.c
@@ -359,7 +359,7 @@ HL_PRIM vbyte *hl_url_decode( vbyte *str, int *len ) {
 				if( *cstr++ != '%' ) break;
 				p4 = decode_hex(&cstr);
 				if( p4 < 0 ) break;
-				k = ((p1 & 0x0F) << 18) | ((p2 & 0x7F) << 12) | ((p3 & 0x7F) << 6) | (p4 & 0x7F);
+				k = (((p1 & 0x0F) << 18) | ((p2 & 0x7F) << 12) | ((p3 & 0x7F) << 6) | (p4 & 0x7F)) - 0x10000;
 				hl_buffer_char(b,(uchar)((k >> 10) + 0xD800));
 				c = (uchar)((k & 0x3FF) | 0xDC00);
 			}

--- a/src/std/string.c
+++ b/src/std/string.c
@@ -129,7 +129,7 @@ HL_PRIM int hl_from_utf8( uchar *out, int outLen, const char *str ) {
 			c = ((c & 0x0F) << 18) | ((c2 & 0x7F) << 12) | ((c3 & 0x7F) << 6) | ((*str++) & 0x7F);
 			// surrogate pair
 			if( p++ == outLen ) break;
-			*out++ = (uchar)((c >> 10) + 0xD7C0);
+			*out++ = (uchar)((c >> 10) + 0xD800);
 			*out++ = (uchar)((c & 0x3FF) | 0xDC00);
 			continue;
 		}
@@ -360,7 +360,7 @@ HL_PRIM vbyte *hl_url_decode( vbyte *str, int *len ) {
 				p4 = decode_hex(&cstr);
 				if( p4 < 0 ) break;
 				k = ((p1 & 0x0F) << 18) | ((p2 & 0x7F) << 12) | ((p3 & 0x7F) << 6) | (p4 & 0x7F);
-				hl_buffer_char(b,(uchar)((k >> 10) + 0xD7C0));
+				hl_buffer_char(b,(uchar)((k >> 10) + 0xD800));
 				c = (uchar)((k & 0x3FF) | 0xDC00);
 			}
 		}

--- a/src/std/string.c
+++ b/src/std/string.c
@@ -126,7 +126,7 @@ HL_PRIM int hl_from_utf8( uchar *out, int outLen, const char *str ) {
 		} else {
 			c2 = (unsigned)*str++;
 			c3 = (unsigned)*str++;
-			c = ((c & 0x0F) << 18) | ((c2 & 0x7F) << 12) | ((c3 & 0x7F) << 6) | ((*str++) & 0x7F);
+			c = (((c & 0x0F) << 18) | ((c2 & 0x7F) << 12) | ((c3 & 0x7F) << 6) | ((*str++) & 0x7F)) - 0x10000;
 			// surrogate pair
 			if( p++ == outLen ) break;
 			*out++ = (uchar)((c >> 10) + 0xD800);
@@ -225,7 +225,7 @@ HL_PRIM vbyte *hl_utf16_to_utf8( vbyte *str, int len, int *size ) {
 			out[p++] = (vbyte)(0xC0|(v>>6));
 			out[p++] = (vbyte)(0x80|(v&63));
 		} else if( v >= 0xD800 && v <= 0xDFFF ) {
-			int k = ((((int)v - 0xD800) << 10) | (((int)*++c) - 0xDC00));
+			int k = ((((int)v - 0xD800) << 10) | (((int)*++c) - 0xDC00)) + 0x10000;
 			out[p++] = (vbyte)(0xF0|(k>>18));
 			out[p++] = (vbyte)(0x80 | ((k >> 12) & 63));
 			out[p++] = (vbyte)(0x80 | ((k >> 6) & 63));
@@ -272,7 +272,7 @@ HL_PRIM vbyte *hl_url_encode( vbyte *str, int *len ) {
 				sur = (unsigned)*cstr;
 				if( sur >= 0xDC00 && sur < 0xDFFF ) {
 					cstr++;
-					c = ((((int)c - 0xD800) << 10) | ((int)sur - 0xDC00));
+					c = ((((int)c - 0xD800) << 10) | ((int)sur - 0xDC00)) + 0x10000;
 					hl_buffer_hex(b, 0xF0|(c>>18));
 					hl_buffer_hex(b, 0x80|((c >> 12) & 63));
 					hl_buffer_hex(b, 0x80|((c >> 6) & 63));

--- a/src/std/sys.c
+++ b/src/std/sys.c
@@ -136,14 +136,12 @@ HL_PRIM vbyte *hl_sys_locale() {
 #endif
 }
 
-vbyte *hl_utf16_to_utf8( vbyte *str, int len, int *size );
-
 HL_PRIM void hl_sys_print( vbyte *msg ) {
 	hl_blocking(true);
 #	ifdef HL_XBO
 	OutputDebugStringW((LPCWSTR)msg);
 #	else
-	printf("%s",(char *)hl_utf16_to_utf8(msg, 0, NULL));
+	uprintf(USTR("%s"),(uchar*)msg);
 	fflush(stdout);
 #	endif
 	hl_blocking(false);

--- a/src/std/sys.c
+++ b/src/std/sys.c
@@ -136,12 +136,14 @@ HL_PRIM vbyte *hl_sys_locale() {
 #endif
 }
 
+vbyte *hl_utf16_to_utf8( vbyte *str, int len, int *size );
+
 HL_PRIM void hl_sys_print( vbyte *msg ) {
 	hl_blocking(true);
 #	ifdef HL_XBO
 	OutputDebugStringW((LPCWSTR)msg);
 #	else
-	uprintf(USTR("%s"),(uchar*)msg);
+	printf("%s",(char *)hl_utf16_to_utf8(msg, 0, NULL));
 	fflush(stdout);
 #	endif
 	hl_blocking(false);

--- a/src/std/ucs2.c
+++ b/src/std/ucs2.c
@@ -50,7 +50,10 @@ int ustrlen_utf8( const uchar *str ) {
 			size++;
 		else if( c < 0x800 )
 			size += 2;
-		else
+		else if( c >= 0xD800 && c <= 0xDFFF ) {
+			str++;
+			size += 4;
+		} else
 			size += 3;
 	}
 	return size;
@@ -133,6 +136,13 @@ int utostr( char *out, int out_size, const uchar *str ) {
 			if( out + 2 > end ) break;
 			*out++ = (char)(0xC0|(c>>6));
 			*out++ = 0x80|(c&63);
+		} else if( c >= 0xD800 && c <= 0xDFFF ) { // surrogate pair
+			if( out + 4 > end ) break;
+			unsigned int full = ((c - 0xD800) << 10) | ((*str++) - 0xDC00);
+			*out++ = (char)(0xF0|(full>>18));
+			*out++ = 0x80|((full>>12)&63);
+			*out++ = 0x80|((full>>6)&63);
+			*out++ = 0x80|(full&63);
 		} else {
 			if( out + 3 > end ) break;
 			*out++ = (char)(0xE0|(c>>12));

--- a/src/std/ucs2.c
+++ b/src/std/ucs2.c
@@ -138,7 +138,7 @@ int utostr( char *out, int out_size, const uchar *str ) {
 			*out++ = 0x80|(c&63);
 		} else if( c >= 0xD800 && c <= 0xDFFF ) { // surrogate pair
 			if( out + 4 > end ) break;
-			unsigned int full = ((c - 0xD800) << 10) | ((*str++) - 0xDC00);
+			unsigned int full = (((c - 0xD800) << 10) | ((*str++) - 0xDC00)) + 0x10000;
 			*out++ = (char)(0xF0|(full>>18));
 			*out++ = 0x80|((full>>12)&63);
 			*out++ = 0x80|((full>>6)&63);


### PR DESCRIPTION
 - ~~convert to UTF-16 before printing in `sys_print` (similar to the fix in hxcpp)~~
 - ~~`0xD7C0` was used instead of `0xD800` for high surrogates~~
 - [x] handle surrogates when calculating string length
 - [x] handle surrogates when converting to UTF-8
 - [x] `Sys.putEnv("TEST_VAR", "😉"); trace(Sys.getEnv("TEST_VAR"));` did not produce the correct result (UTF-16 to UTF-8 conversion was wrong)
 - [x] https://github.com/HaxeFoundation/haxe/issues/8204 ? cannot reproduce yet
