### PR TITLE
Fix duplicate LF->CRLF encoding

### DIFF
--- a/src/hl.h
+++ b/src/hl.h
@@ -223,10 +223,6 @@ typedef wchar_t	uchar;
 #	define uprintf		wprintf
 #	define ustrlen		wcslen
 #	define ustrdup		_wcsdup
-#	ifdef HL_WIN_DESKTOP
-#		define printf		hl_win_cprintf
-HL_API void hl_win_cprintf( const char *fmt, ... );
-#	endif
 HL_API int uvszprintf( uchar *out, int out_size, const uchar *fmt, va_list arglist );
 #	define utod(s,end)	wcstod(s,end)
 #	define utoi(s,end)	wcstol(s,end,10)

--- a/src/hl.h
+++ b/src/hl.h
@@ -227,7 +227,6 @@ HL_API int uvszprintf( uchar *out, int out_size, const uchar *fmt, va_list argli
 #	define utod(s,end)	wcstod(s,end)
 #	define utoi(s,end)	wcstol(s,end,10)
 #	define ucmp(a,b)	wcscmp(a,b)
-#	define utostr(out,size,str) wcstombs(out,str,size)
 #elif defined(HL_MAC)
 typedef uint16_t uchar;
 #	undef USTR
@@ -247,6 +246,10 @@ typedef char16_t uchar;
 #	define USTR(str)	u##str
 #endif
 
+HL_API int ustrlen_utf8( const uchar *str );
+HL_API int utostr( char *out, int out_size, const uchar *str );
+HL_API char *utos( const uchar *s );
+
 #ifndef HL_NATIVE_UCHAR_FUN
 C_FUNCTION_BEGIN
 HL_API int ustrlen( const uchar *str );
@@ -254,7 +257,6 @@ HL_API uchar *ustrdup( const uchar *str );
 HL_API double utod( const uchar *str, uchar **end );
 HL_API int utoi( const uchar *str, uchar **end );
 HL_API int ucmp( const uchar *a, const uchar *b );
-HL_API int utostr( char *out, int out_size, const uchar *str );
 HL_API int usprintf( uchar *out, int out_size, const uchar *fmt, ... );
 HL_API int uvszprintf( uchar *out, int out_size, const uchar *fmt, va_list arglist );
 HL_API void uprintf( const uchar *fmt, const uchar *str );

--- a/src/std/sys.c
+++ b/src/std/sys.c
@@ -138,61 +138,6 @@ HL_PRIM vbyte *hl_sys_locale() {
 #endif
 }
 
-static int ustrlen_utf8( const uchar *str ) {
-	int size = 0;
-	while(1) {
-		uchar c = *str++;
-		if( c == 0 ) break;
-		if( c < 0x80 )
-			size++;
-		else if( c < 0x800 )
-			size += 2;
-		else if( c >= 0xD800 && c <= 0xDFFF ) {
-			str++;
-			size += 4;
-		} else
-			size += 3;
-	}
-	return size;
-}
-static int fix_utostr( char *out, int out_size, const uchar *str ) {
-	char *start = out;
-	char *end = out + out_size - 1; // final 0
-	if( out_size <= 0 ) return 0;
-	while( out < end ) {
-		unsigned int c = *str++;
-		if( c == 0 ) break;
-		if( c < 0x80 )
-			*out++ = (char)c;
-		else if( c < 0x800 ) {
-			if( out + 2 > end ) break;
-			*out++ = (char)(0xC0|(c>>6));
-			*out++ = 0x80|(c&63);
-		} else if( c >= 0xD800 && c <= 0xDFFF ) { // surrogate pair
-			if( out + 4 > end ) break;
-			unsigned int full = (((c - 0xD800) << 10) | ((*str++) - 0xDC00)) + 0x10000;
-			*out++ = (char)(0xF0|(full>>18));
-			*out++ = 0x80|((full>>12)&63);
-			*out++ = 0x80|((full>>6)&63);
-			*out++ = 0x80|(full&63);
-		} else {
-			if( out + 3 > end ) break;
-			*out++ = (char)(0xE0|(c>>12));
-			*out++ = 0x80|((c>>6)&63);
-			*out++ = 0x80|(c&63);
-		}
-	}
-	*out = 0;
-	return (int)(out - start);
-}
-static char *utos( const uchar *s ) {
-	int len = ustrlen_utf8(s);
-	char *out = (char*)malloc(len + 1);
-	if( fix_utostr(out,len+1,s) < 0 )
-		*out = 0;
-	return out;
-}
-
 HL_PRIM void hl_sys_print( vbyte *msg ) {
 	hl_blocking(true);
 #	ifdef HL_XBO

--- a/src/std/ucs2.c
+++ b/src/std/ucs2.c
@@ -261,19 +261,4 @@ sprintf_add:
 	return 0;
 }
 
-#ifdef HL_WIN
-// we can no longer use basic printf after we changed the console output encoding
-HL_PRIM void hl_win_cprintf( const char *fmt, ... ) {
-	char buf[4096];
-	uchar ubuf[4096];
-	va_list args;
-	va_start(args, fmt);
-	vsprintf(buf, fmt, args);
-	va_end(args);
-	hl_from_utf8(ubuf,4096,buf);
-	wprintf(USTR("%s"),ubuf);
-	fflush(stdout);
-}
-#endif
-
 #endif

--- a/src/std/ucs2.c
+++ b/src/std/ucs2.c
@@ -22,6 +22,64 @@
 #include <hl.h>
 #include <stdarg.h>
 
+int ustrlen_utf8( const uchar *str ) {
+	int size = 0;
+	while(1) {
+		uchar c = *str++;
+		if( c == 0 ) break;
+		if( c < 0x80 )
+			size++;
+		else if( c < 0x800 )
+			size += 2;
+		else if( c >= 0xD800 && c <= 0xDFFF ) {
+			str++;
+			size += 4;
+		} else
+			size += 3;
+	}
+	return size;
+}
+
+// USE UTF-8 encoding
+int utostr( char *out, int out_size, const uchar *str ) {
+	char *start = out;
+	char *end = out + out_size - 1; // final 0
+	if( out_size <= 0 ) return 0;
+	while( out < end ) {
+		unsigned int c = *str++;
+		if( c == 0 ) break;
+		if( c < 0x80 )
+			*out++ = (char)c;
+		else if( c < 0x800 ) {
+			if( out + 2 > end ) break;
+			*out++ = (char)(0xC0|(c>>6));
+			*out++ = 0x80|(c&63);
+		} else if( c >= 0xD800 && c <= 0xDFFF ) { // surrogate pair
+			if( out + 4 > end ) break;
+			unsigned int full = (((c - 0xD800) << 10) | ((*str++) - 0xDC00)) + 0x10000;
+			*out++ = (char)(0xF0|(full>>18));
+			*out++ = 0x80|((full>>12)&63);
+			*out++ = 0x80|((full>>6)&63);
+			*out++ = 0x80|(full&63);
+		} else {
+			if( out + 3 > end ) break;
+			*out++ = (char)(0xE0|(c>>12));
+			*out++ = 0x80|((c>>6)&63);
+			*out++ = 0x80|(c&63);
+		}
+	}
+	*out = 0;
+	return (int)(out - start);
+}
+
+char *utos( const uchar *s ) {
+	int len = ustrlen_utf8(s);
+	char *out = (char*)malloc(len + 1);
+	if( utostr(out,len+1,s) < 0 )
+		*out = 0;
+	return out;
+}
+
 #ifndef HL_NATIVE_UCHAR_FUN
 
 #ifdef HL_ANDROID
@@ -39,24 +97,6 @@ int ustrlen( const uchar *str ) {
 	const uchar *p = str;
 	while( *p ) p++;
 	return (int)(p - str);
-}
-
-int ustrlen_utf8( const uchar *str ) {
-	int size = 0;
-	while(1) {
-		uchar c = *str++;
-		if( c == 0 ) break;
-		if( c < 0x80 )
-			size++;
-		else if( c < 0x800 )
-			size += 2;
-		else if( c >= 0xD800 && c <= 0xDFFF ) {
-			str++;
-			size += 4;
-		} else
-			size += 3;
-	}
-	return size;
 }
 
 uchar *ustrdup( const uchar *str ) {
@@ -120,46 +160,6 @@ int usprintf( uchar *out, int out_size, const uchar *fmt, ... ) {
 	ret = uvszprintf(out, out_size, fmt, args);
 	va_end(args);
 	return ret;
-}
-
-// USE UTF-8 encoding
-int utostr( char *out, int out_size, const uchar *str ) {
-	char *start = out;
-	char *end = out + out_size - 1; // final 0
-	if( out_size <= 0 ) return 0;
-	while( out < end ) {
-		unsigned int c = *str++;
-		if( c == 0 ) break;
-		if( c < 0x80 )
-			*out++ = (char)c;
-		else if( c < 0x800 ) {
-			if( out + 2 > end ) break;
-			*out++ = (char)(0xC0|(c>>6));
-			*out++ = 0x80|(c&63);
-		} else if( c >= 0xD800 && c <= 0xDFFF ) { // surrogate pair
-			if( out + 4 > end ) break;
-			unsigned int full = (((c - 0xD800) << 10) | ((*str++) - 0xDC00)) + 0x10000;
-			*out++ = (char)(0xF0|(full>>18));
-			*out++ = 0x80|((full>>12)&63);
-			*out++ = 0x80|((full>>6)&63);
-			*out++ = 0x80|(full&63);
-		} else {
-			if( out + 3 > end ) break;
-			*out++ = (char)(0xE0|(c>>12));
-			*out++ = 0x80|((c>>6)&63);
-			*out++ = 0x80|(c&63);
-		}
-	}
-	*out = 0;
-	return (int)(out - start);
-}
-
-static char *utos( const uchar *s ) {
-	int len = ustrlen_utf8(s);
-	char *out = (char*)malloc(len + 1);
-	if( utostr(out,len+1,s) < 0 )
-		*out = 0;
-	return out;
 }
 
 void uprintf( const uchar *fmt, const uchar *str ) {


### PR DESCRIPTION
See HaxeFoundation/haxe#8379

 - in `hl_sys_print`, switch stdout to binary mode, convert string to UTF-8, output it, then switch back
 - in `ucs2.c` make the functions `ustrlen_utf8`, `utostr`, and `utos` always be defined
 - remove alias `utostr` -> `wcstombs` on Windows, since it relies on the locale type