### PR TITLE
update hl_sys_time to support OS below Windows 8

### DIFF
--- a/src/std/sys.c
+++ b/src/std/sys.c
@@ -164,21 +164,30 @@ HL_PRIM void hl_sys_exit( int code ) {
 HL_PRIM double hl_sys_time() {
 #ifdef HL_WIN
 	#define EPOCH_DIFF	(134774*24*60*60.0)
+	static double time_diff = 0.;
 	static double freq = 0.;
 	LARGE_INTEGER time;
+	LARGE_INTEGER start_time;
 	FILETIME ft;
+
 	if( freq == 0 ) {
 		QueryPerformanceFrequency(&time);
 		freq = (double)time.QuadPart;
 	}
-	#if (_WIN32_WINNT < _WIN32_WINNT_WIN8)
-	GetSystemTimeAsFileTime(&ft);
-	#else
-	GetSystemTimePreciseAsFileTime(&ft);
-	#endif
-	time.LowPart = ft.dwLowDateTime;
-	time.HighPart = ft.dwHighDateTime;
-	return ((double)time.QuadPart) / freq - EPOCH_DIFF;
+	QueryPerformanceCounter(&time);
+
+	if( time_diff == 0 ) {
+		#if (_WIN32_WINNT < _WIN32_WINNT_WIN8)
+		GetSystemTimeAsFileTime(&ft);
+		#else
+		GetSystemTimePreciseAsFileTime(&ft);
+		#endif
+		start_time.LowPart = ft.dwLowDateTime;
+		start_time.HighPart = ft.dwHighDateTime;
+		time_diff = ((double)start_time.QuadPart - (double)time.QuadPart) / freq - EPOCH_DIFF;
+	}
+
+	return time_diff + ((double)time.QuadPart) / freq;
 #else
 	struct timeval tv;
 	if( gettimeofday(&tv,NULL) != 0 )

--- a/src/std/sys.c
+++ b/src/std/sys.c
@@ -177,11 +177,7 @@ HL_PRIM double hl_sys_time() {
 	QueryPerformanceCounter(&time);
 
 	if( time_diff == 0 ) {
-		#if (_WIN32_WINNT < _WIN32_WINNT_WIN8)
 		GetSystemTimeAsFileTime(&ft);
-		#else
-		GetSystemTimePreciseAsFileTime(&ft);
-		#endif
 		start_time.LowPart = ft.dwLowDateTime;
 		start_time.HighPart = ft.dwHighDateTime;
 		time_diff = ((double)start_time.QuadPart - (double)time.QuadPart) / freq - EPOCH_DIFF;

--- a/src/std/sys.c
+++ b/src/std/sys.c
@@ -171,7 +171,11 @@ HL_PRIM double hl_sys_time() {
 		QueryPerformanceFrequency(&time);
 		freq = (double)time.QuadPart;
 	}
+	#if (_WIN32_WINNT < _WIN32_WINNT_WIN8)
+	GetSystemTimeAsFileTime(&ft);
+	#else
 	GetSystemTimePreciseAsFileTime(&ft);
+	#endif
 	time.LowPart = ft.dwLowDateTime;
 	time.HighPart = ft.dwHighDateTime;
 	return ((double)time.QuadPart) / freq - EPOCH_DIFF;


### PR DESCRIPTION
#281 
_Originally posted by @Shoozza in https://github.com/HaxeFoundation/hashlink/pull/281#issuecomment-523223056_

[GetSystemTimePreciseAsFileTime](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsystemtimepreciseasfiletime) supported since Windows 8
[GetSystemTimeAsFileTime](https://docs.microsoft.com/ru-ru/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsystemtimeasfiletime) supported since Windows 2000 Professional



