### PR TITLE
add PCRE_NO_UTF8_CHECK option

### DIFF
--- a/src/std/regexp.c
+++ b/src/std/regexp.c
@@ -104,7 +104,7 @@ HL_PRIM int hl_regexp_matched_pos( ereg *e, int m, int *len ) {
 }
 
 HL_PRIM bool hl_regexp_match( ereg *e, vbyte *s, int pos, int len ) {
-	int res = pcre16_exec(e->p,&limit,(PCRE_SPTR16)s,pos+len,pos,0,e->matches,e->nmatches * 3);
+	int res = pcre16_exec(e->p,&limit,(PCRE_SPTR16)s,pos+len,pos,PCRE_NO_UTF8_CHECK,e->matches,e->nmatches * 3);
 	e->matched = res >= 0;
 	if( res >= 0 )
 		return true;


### PR DESCRIPTION
Option to disable utf8 checks every regexp_match call

check off: `0.11178874969482s`
check on: `2.42371964454651s`

Sample code:
```haxe
class Main 
{
	static function main( )
	{
		var str = StringTools.lpad('', '"', 10 * 1024);
		var r = ~/"/g;
		haxe.Timer.measure(function(){
			for(i in 0...10)
				replace(r, str);
		});
	}

	static function replace( r : EReg, str : String )
	{
		str = r.replace(str, '');
	}
}
```