### PR TITLE
Added error popup for failed SDL window creation

### DIFF
--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -429,6 +429,11 @@ HL_PRIM SDL_Window *HL_NAME(win_create_ex)(int x, int y, int width, int height, 
 #else
 	w = SDL_CreateWindow("", x, y, width, height, SDL_WINDOW_OPENGL | sdlFlags);
 #endif
+
+	if (w == NULL) {
+		hl_error("SDL_CreateWindow failed: %s", hl_to_utf16(SDL_GetError()));
+	}
+
 #	ifdef HL_WIN
 	// force window to show even if the debugger force process windows to be hidden
 	if( (SDL_GetWindowFlags(w) & SDL_WINDOW_INPUT_FOCUS) == 0 ) {


### PR DESCRIPTION
The dialog will show a bit more detailed info retrieved from `SDL_GetError`.