### PR TITLE
libs/fmt: Compile fmt.hdll with mikktspace

### DIFF
--- a/libs/fmt/CMakeLists.txt
+++ b/libs/fmt/CMakeLists.txt
@@ -1,3 +1,6 @@
+set(MINIMP3_INCLUDE_DIR ${INCLUDES_BASE_DIR}/minimp3)
+set(MIKKTSPACE_INCLUDE_DIR ${INCLUDES_BASE_DIR}/mikktspace)
+
 if(WIN32)
     set(ZLIB_INCLUDE_DIRS ${INCLUDES_BASE_DIR}/zlib)
     set(PNG_INCLUDE_DIRS ${INCLUDES_BASE_DIR}/png)
@@ -133,10 +136,10 @@ else()
         fmt.c
         sha1.c
         dxt.c
+        mikkt.c
+        ${MIKKTSPACE_INCLUDE_DIR}/mikktspace.c
     )
 endif()
-
-set(MINIMP3_INCLUDE_DIR ${INCLUDES_BASE_DIR}/minimp3)
 
 set_as_hdll(fmt)
 
@@ -147,6 +150,7 @@ target_include_directories(fmt.hdll
     ${TurboJPEG_INCLUDE_DIRS}
     ${VORBIS_INCLUDE_DIR}
     ${MINIMP3_INCLUDE_DIR}
+    ${MIKKTSPACE_INCLUDE_DIR}
 )
 
 target_link_libraries(fmt.hdll


### PR DESCRIPTION
Compile fmt.hdll with libs/fmt/mikkt.c and include/mikktspace/mikktspace.c for all OSes.