### PR TITLE
Added possibility to switch to borderless fullscreen on non windows

### DIFF
--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -491,7 +491,7 @@ HL_PRIM bool HL_NAME(win_set_fullscreen)(SDL_Window *win, int mode) {
 			return true;
 		}
 #	else
-		break;
+		return SDL_SetWindowFullscreen(win, SDL_WINDOW_FULLSCREEN_DESKTOP) == 0;
 #	endif
 	case 3:
 		return SDL_SetWindowFullscreen(win, SDL_WINDOW_FULLSCREEN) == 0;


### PR DESCRIPTION
It works the same as setting the displayMode to 1, Fullscreen. It seems better than not doing anything on non-windows platform when trying to set the mode to Borderless.