### PR TITLE
minor improvements to OS X installation routine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ codesign_osx:
 	echo "[req]\ndistinguished_name=codesign_dn\n[codesign_dn]\ncommonName=hl-cert\n[v3_req]\nkeyUsage=critical,digitalSignature\nextendedKeyUsage=critical,codeSigning" > openssl.cnf
 	openssl req -x509 -newkey rsa:4096 -keyout key.pem -nodes -days 365 -subj '/CN=hl-cert' -outform der -out cert.cer -extensions v3_req -config openssl.cnf
 	sudo security add-trusted-cert -d -k /Library/Keychains/System.keychain cert.cer
-	sudo security import key.pem -k /Library/Keychains/System.keychain
+	sudo security import key.pem -k /Library/Keychains/System.keychain -A
 	codesign --entitlements other/osx/entitlements.xml -fs hl-cert hl
 	rm key.pem cert.cer openssl.cnf
 

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ endif
 all: libhl hl libs
 
 install:
+	$(UNAME)==Darwin && make uninstall
 	mkdir -p $(INSTALL_BIN_DIR)
 	cp hl $(INSTALL_BIN_DIR)
 	mkdir -p $(INSTALL_LIB_DIR)
@@ -208,12 +209,12 @@ release_osx:
 	rm -rf hl-$(HL_VER)
 
 codesign_osx:
+	sudo security delete-identity -c hl-cert || echo
 	echo "[req]\ndistinguished_name=codesign_dn\n[codesign_dn]\ncommonName=hl-cert\n[v3_req]\nkeyUsage=critical,digitalSignature\nextendedKeyUsage=critical,codeSigning" > openssl.cnf
 	openssl req -x509 -newkey rsa:4096 -keyout key.pem -nodes -days 365 -subj '/CN=hl-cert' -outform der -out cert.cer -extensions v3_req -config openssl.cnf
 	sudo security add-trusted-cert -d -k /Library/Keychains/System.keychain cert.cer
 	sudo security import key.pem -k /Library/Keychains/System.keychain
 	codesign --entitlements other/osx/entitlements.xml -fs hl-cert hl
-	sudo security delete-identity -c hl-cert
 	rm key.pem cert.cer openssl.cnf
 
 .SUFFIXES : .c .o

--- a/other/azure-pipelines/build-mac.yml
+++ b/other/azure-pipelines/build-mac.yml
@@ -29,8 +29,6 @@ jobs:
           displayName: CMake
         - script: make
           displayName: Build
-        - script: sudo make codesign_osx
-          displayName: Codesign
         - script: |
             set -ex
             otool -L ./bin/hl


### PR DESCRIPTION
This tiny PR fixes two issues related to codesigning in OSX:

1) The "hl-cert" signing identity is now removed prior to generating a new certificate, rather then after. This prevents duplicate certificates of the same name – which is actually possible – being created when the command fails before the signing identity could be removed in the old version.

2) There is an issue with MacOS's security during `make install` which does not allow replacement of differently signed `hl` executables in `/usr/local...`. We therefore need to explicitly uninstall and then install to make this possible and prevent signing corruption

@qkdreyer @ncannasse 