### PR TITLE
[UNIX] Don't crash on SIGPIPE

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -125,6 +125,7 @@ static void setup_handler() {
 	act.sa_handler = handle_signal;
 	act.sa_flags = 0;
 	sigemptyset(&act.sa_mask);
+	signal(SIGPIPE, SIG_IGN);
 	sigaction(SIGSEGV,&act,NULL);
 	sigaction(SIGTERM,&act,NULL);
 }


### PR DESCRIPTION
Currently, when running on linux (didn't test on macos) if remote socket hangs up the whole application silently crashes with SIGPIPE (and no stacktrace). I traced it all the way to libuv that does this on purpose for performance reasons (see https://github.com/joyent/libuv/issues/1254#issuecomment-41185781). The recommended (as I understood it) way to prevent crashes is to redirect SIGPIPE to SIG_IGN and handle socket errors in user code instead.