### PR TITLE
Fix build for ARM Linux

### DIFF
--- a/src/std/debug.c
+++ b/src/std/debug.c
@@ -20,7 +20,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 #include <hl.h>
-#ifdef HL_LINUX
+#if defined(HL_LINUX) && (defined(__i386__) || defined(__x86_64__))
 #	include <sys/ptrace.h>
 #	include <sys/wait.h>
 #	include <sys/user.h>


### PR DESCRIPTION
The current usage of USE_PTRACE depends on some x86-isms, which just break the build on ARM. This fixes hl/c build on Raspberry Pi.