### PR TITLE
add broadcast ability to udp sockets

### DIFF
--- a/src/std/socket.c
+++ b/src/std/socket.c
@@ -135,8 +135,9 @@ HL_PRIM hl_socket *hl_socket_new( bool udp ) {
 
 HL_PRIM bool hl_socket_set_broadcast( hl_socket *s, bool b ) {
 	int broadcast = b;
-	if( !s ) return false;
-    return setsockopt(s->sock,SOL_SOCKET,SO_BROADCAST,(char*)&broadcast,sizeof(broadcast)) == 0;
+	if( !s )
+		return false;
+	return setsockopt(s->sock,SOL_SOCKET,SO_BROADCAST,(char*)&broadcast,sizeof(broadcast)) == 0;
 }
 
 HL_PRIM void hl_socket_close( hl_socket *s ) {

--- a/src/std/socket.c
+++ b/src/std/socket.c
@@ -134,9 +134,9 @@ HL_PRIM hl_socket *hl_socket_new( bool udp ) {
 }
 
 HL_PRIM bool hl_socket_set_broadcast( hl_socket *s, bool b ) {
-	int fast = b;
+	int broadcast = b;
 	if( !s ) return false;
-    return setsockopt(s->sock,SOL_SOCKET,SO_BROADCAST,(char*)&fast,sizeof(fast)) == 0;
+    return setsockopt(s->sock,SOL_SOCKET,SO_BROADCAST,(char*)&broadcast,sizeof(broadcast)) == 0;
 }
 
 HL_PRIM void hl_socket_close( hl_socket *s ) {

--- a/src/std/socket.c
+++ b/src/std/socket.c
@@ -133,6 +133,12 @@ HL_PRIM hl_socket *hl_socket_new( bool udp ) {
 	}
 }
 
+HL_PRIM bool hl_socket_set_broadcast( hl_socket *s, bool b ) {
+	int fast = b;
+	if( !s ) return false;
+    return setsockopt(s->sock,SOL_SOCKET,SO_BROADCAST,(char*)&fast,sizeof(fast)) == 0;
+}
+
 HL_PRIM void hl_socket_close( hl_socket *s ) {
 	if( !s ) return;
 	closesocket(s->sock);
@@ -478,6 +484,7 @@ HL_PRIM bool hl_socket_select( varray *ra, varray *wa, varray *ea, char *tmp, in
 #define _SOCK	_ABSTRACT(hl_socket)
 DEFINE_PRIM(_VOID,socket_init,_NO_ARG);
 DEFINE_PRIM(_SOCK,socket_new,_BOOL);
+DEFINE_PRIM(_BOOL,socket_set_broadcast,_SOCK _BOOL);
 DEFINE_PRIM(_VOID,socket_close,_SOCK);
 DEFINE_PRIM(_I32,socket_send_char,_SOCK _I32);
 DEFINE_PRIM(_I32,socket_send,_SOCK _BYTES _I32 _I32 );


### PR DESCRIPTION
Hello,

Trying out heaps.io, I noticed, that the implementation for sockets was missing the `setBroadcast` function for udp.

I hope I implemented this correctly as it isn't a big diff. 

I tested sending broadcasts with ubuntu 20.04, haxe 4.1.4, heaps 1.8.0
They showed up in wireshark and I could recieve them on another machine in the same network.