### PR TITLE
Fix linux Makefile flags and new function for maps/regexps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ else
 
 # Linux
 CFLAGS += -m$(MARCH) -fPIC -pthread -fno-omit-frame-pointer
-LFLAGS += -lm -Wl,-rpath,.:'$ORIGIN/../lib':$(PREFIX)/lib -Wl,--export-dynamic -Wl,--no-undefined
+LFLAGS += -lm -Wl,-rpath,. -Wl,--export-dynamic -Wl,--no-undefined
 
 ifeq ($(MARCH),32)
 CFLAGS += -I /usr/include/i386-linux-gnu

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ else
 
 # Linux
 CFLAGS += -m$(MARCH) -fPIC -pthread -fno-omit-frame-pointer
-LFLAGS += -lm -Wl,-rpath,. -Wl,--export-dynamic -Wl,--no-undefined
+LFLAGS += -lm -Wl,-rpath,.:'$ORIGIN/../lib':$(PREFIX)/lib -Wl,--export-dynamic -Wl,--no-undefined
 
 ifeq ($(MARCH),32)
 CFLAGS += -I /usr/include/i386-linux-gnu

--- a/src/std/maps.c
+++ b/src/std/maps.c
@@ -234,6 +234,7 @@ DEFINE_PRIM( _BOOL, hiremove, _IMAP _I32 );
 DEFINE_PRIM( _ARR, hikeys, _IMAP );
 DEFINE_PRIM( _ARR, hivalues, _IMAP );
 DEFINE_PRIM( _VOID, hiclear, _IMAP );
+DEFINE_PRIM( _I32, hisize, _IMAP );
 
 #define _BMAP _ABSTRACT(hl_bytes_map)
 DEFINE_PRIM( _BMAP, hballoc, _NO_ARG );
@@ -244,6 +245,7 @@ DEFINE_PRIM( _BOOL, hbremove, _BMAP _BYTES );
 DEFINE_PRIM( _ARR, hbkeys, _BMAP );
 DEFINE_PRIM( _ARR, hbvalues, _BMAP );
 DEFINE_PRIM( _VOID, hbclear, _BMAP );
+DEFINE_PRIM( _I32, hbsize, _BMAP );
 
 #define _OMAP _ABSTRACT(hl_obj_map)
 DEFINE_PRIM( _OMAP, hoalloc, _NO_ARG );
@@ -254,3 +256,4 @@ DEFINE_PRIM( _BOOL, horemove, _OMAP _DYN );
 DEFINE_PRIM( _ARR, hokeys, _OMAP );
 DEFINE_PRIM( _ARR, hovalues, _OMAP );
 DEFINE_PRIM( _VOID, hoclear, _OMAP );
+DEFINE_PRIM( _I32, hosize, _OMAP );

--- a/src/std/maps.h
+++ b/src/std/maps.h
@@ -188,6 +188,10 @@ HL_PRIM void _MNAME(clear)( t_map *m ) {
 	memset(m,0,sizeof(t_map));
 }
 
+HL_PRIM int _MNAME(size)( t_map *m ) {
+	return m->nentries;
+}
+
 
 #undef hlt_key
 #undef hl_hbhash

--- a/src/std/regexp.c
+++ b/src/std/regexp.c
@@ -105,8 +105,9 @@ HL_PRIM int hl_regexp_matched_pos( ereg *e, int m, int *len ) {
 
 HL_PRIM int hl_regexp_matched_num( ereg *e ) {
 	if( !e->matched )
-		hl_error("Calling matchedNum() on an unmatched regexp"); 
-	return e->nmatches;
+		return -1;
+	else
+		return e->nmatches;
 }
 
 HL_PRIM bool hl_regexp_match( ereg *e, vbyte *s, int pos, int len ) {

--- a/src/std/regexp.c
+++ b/src/std/regexp.c
@@ -103,6 +103,12 @@ HL_PRIM int hl_regexp_matched_pos( ereg *e, int m, int *len ) {
 	return start;
 }
 
+HL_PRIM int hl_regexp_matched_num( ereg *e ) {
+	if( !e->matched )
+		hl_error("Calling matchedNum() on an unmatched regexp"); 
+	return e->nmatches;
+}
+
 HL_PRIM bool hl_regexp_match( ereg *e, vbyte *s, int pos, int len ) {
 	int res = pcre16_exec(e->p,&limit,(PCRE_SPTR16)s,pos+len,pos,PCRE_NO_UTF16_CHECK,e->matches,e->nmatches * 3);
 	e->matched = res >= 0;
@@ -116,5 +122,5 @@ HL_PRIM bool hl_regexp_match( ereg *e, vbyte *s, int pos, int len ) {
 #define _EREG _ABSTRACT(ereg)
 DEFINE_PRIM( _EREG, regexp_new_options, _BYTES _BYTES);
 DEFINE_PRIM( _I32, regexp_matched_pos, _EREG _I32 _REF(_I32));
+DEFINE_PRIM( _I32, regexp_matched_num, _EREG );
 DEFINE_PRIM( _BOOL, regexp_match, _EREG _BYTES _I32 _I32);
-


### PR DESCRIPTION
So for starters, I fixed the installation issue on Linux that everyone seems to be complaining about.

Secondly, I added 2 (technically 4) functions to the builtin stdlib, which is step 1 of several for a PR that I'm working on for Haxe.
The functions are as follows:
- `hisize`/`hbsize`/`hosize`: Return the number of entries in the map.
- `regexp_matched_num`: Return the number of matched groups from the last time a regexp was matched.