### PR TITLE
fix cleanup for main

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -762,6 +762,12 @@ static void hl_gc_init() {
 #	endif
 }
 
+static void hl_gc_free() {
+#	ifdef HL_THREADS
+	hl_remove_root(&gc_threads.global_lock);
+#	endif
+}
+
 // ---- UTILITIES ----------------------
 
 HL_API bool hl_is_blocking() {
@@ -806,6 +812,7 @@ void hl_global_init() {
 
 void hl_global_free() {
 	hl_cache_free();
+	hl_gc_free();
 }
 
 struct hl_alloc_block {

--- a/src/main.c
+++ b/src/main.c
@@ -244,6 +244,7 @@ int main(int argc, pchar *argv[]) {
 	}
 	hl_module_free(ctx.m);
 	hl_free(&ctx.code->alloc);
+	hl_unregister_thread();
 	hl_global_free();
 	return 0;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -753,6 +753,10 @@ h_bool hl_module_patch( hl_module *m1, hl_code *c ) {
 }
 
 void hl_module_free( hl_module *m ) {
+	for(int i=0;i<m->code->nglobals;i++) {
+		if( hl_is_ptr(m->code->globals[i]) )
+			hl_remove_root(m->globals_data+m->globals_indexes[i]);
+	}
 	hl_free(&m->ctx.alloc);
 	hl_free_executable_memory(m->code, m->codesize);
 	if( m->hash ) hl_code_hash_free(m->hash);


### PR DESCRIPTION
Closes #452 (at least i cannot reproduce the failure with 3 reloads anymore).

Two things so far that i found that make cleanup in main not complete:

- In `main` there is a call to [`hl_register_thread`](https://github.com/HaxeFoundation/hashlink/blob/c2786410a0fc525edda88b266fee1158efc38f44/src/main.c#L207), but no call to `hl_unregister_thread` at the end. (For `main` itself it is ok since it does not care much about full cleanup before exit, but it can be used as a reference point for proper integration and better to make it right.)

- In `hl_module_init` globals are passed to [`hl_add_root`](https://github.com/HaxeFoundation/hashlink/blob/c2786410a0fc525edda88b266fee1158efc38f44/src/module.c#L521), but in `hl_module_free` globals [are freed](https://github.com/HaxeFoundation/hashlink/blob/c2786410a0fc525edda88b266fee1158efc38f44/src/module.c#L763) without being removed as gc roots.