### PR TITLE
Add static library build to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ ifdef DEBUG
 CFLAGS += -g
 endif
 
-all: libhl hl libs
+all: libhl hl libs libhl.a
 
 install:
 	$(UNAME)==Darwin && make uninstall
@@ -162,6 +162,9 @@ mysql: ${MYSQL} libhl
 
 mesa:
 	(cd libs/mesa && make)
+
+libhl.a: ${LIB} ${FMT} ${SDL} ${SSL} ${OPENAL} ${UI} ${UV} ${MYSQL}
+	ar rcs $@ $^
 
 release: release_version release_$(RELEASE_NAME)
 
@@ -223,10 +226,13 @@ codesign_osx:
 .c.o :
 	${CC} ${CFLAGS} -o $@ -c $<
 
+clean_a:
+	rm -f libhl.a
+
 clean_o:
 	rm -f ${STD} ${BOOT} ${RUNTIME} ${PCRE} ${HL} ${FMT} ${SDL} ${SSL} ${OPENAL} ${UI} ${UV} ${HL_DEBUG}
 
-clean: clean_o
+clean: clean_o clean_a
 	rm -f hl hl.exe libhl.$(LIBEXT) *.hdll
 
 .PHONY: libhl hl hlc fmt sdl libs release


### PR DESCRIPTION
Added a new target `libhl.a` to `Makefile` for statically linking your app to Hashlink. This gets rid of the need to to bundle `libhl.so` and the `*.hdll` files which some may find useful.

Tested locally and works fine.