### PR TITLE
Fix linux dynamic library issue when installing to `/usr/local/`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,10 @@ add_executable(hl
 	src/profile.c
 )
 
+if (UNIX AND NOT APPLE)
+    set_target_properties(hl PROPERTIES INSTALL_RPATH "$ORIGIN;${CMAKE_INSTALL_PREFIX}/lib")
+endif()
+
 target_link_libraries(hl libhl)
 
 if(WIN32)

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ else
 
 # Linux
 CFLAGS += -m$(MARCH) -fPIC -pthread -fno-omit-frame-pointer
-LFLAGS += -lm -Wl,-rpath,. -Wl,--export-dynamic -Wl,--no-undefined
+LFLAGS += -lm -Wl,-rpath,.:'$$ORIGIN':$(INSTALL_LIB_DIR) -Wl,--export-dynamic -Wl,--no-undefined
 
 ifeq ($(MARCH),32)
 CFLAGS += -I /usr/include/i386-linux-gnu


### PR DESCRIPTION
Resolves #386

The way this is solved is by modifying rpath settings. The hl executable will search its original path first (for relocatable builds, for testing and development etc) then the installation library path. Addresses both make and cmake.

It might be useful to have a setting to switch between the relocatable build and the installable build, however for now this works fine.