### PR TITLE
GHA: Don't try to upload non-existing 32bit binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -335,13 +335,13 @@ jobs:
 
         # https://hub.github.com/hub-release.1.html
         hub release create "latest" \
+          --prerelease \
           --message "latest" \
           --attach "artifact/hashlink-latest-darwin.tar.gz" \
-          --attach "artifact/hashlink-latest-linux-i386.tar.gz" \
           --attach "artifact/hashlink-latest-linux-amd64.tar.gz" \
           --attach "artifact/hashlink-latest-win32.zip" \
-          --attach "artifact/hashlink-latest-win64.zip" \
-          --prerelease
+          --attach "artifact/hashlink-latest-win64.zip"
+          #--attach "artifact/hashlink-latest-linux-i386.tar.gz"
 
     - name: "Delete intermediate build artifacts"
       uses: geekyeggo/delete-artifact@1-glob-support # https://github.com/GeekyEggo/delete-artifact/


### PR DESCRIPTION
@ncannasse GHA build fails because I had to disable 32bit Linux builds but the release step still tried to upload the (not-build) 32bit binaries