### PR TITLE
cmake: Link sdl.hdll with OpenGL

### DIFF
--- a/libs/sdl/CMakeLists.txt
+++ b/libs/sdl/CMakeLists.txt
@@ -25,8 +25,8 @@ if(WIN32)
     )
 endif()
 
-if(APPLE)
-    find_package(OPENGL REQUIRED)
+if(APPLE OR UNIX)
+    find_package(OpenGL REQUIRED)
     target_include_directories(sdl.hdll
         PRIVATE
         ${OPENGL_INCLUDE_DIR}


### PR DESCRIPTION
On openSUSE the packages are build with -Wl,--no-undefined and it would fail because of missing symbols