### PR TITLE
cmake: Allow running the uvsample tests in parallel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,7 +274,7 @@ if(BUILD_TESTING)
         COMMAND hl ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test/threads.hl
     )
     add_test(NAME uvsample.hl
-        COMMAND hl ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test/uvsample.hl
+        COMMAND hl ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test/uvsample.hl 6001
     )
     add_test(NAME hello
         COMMAND hello
@@ -283,7 +283,7 @@ if(BUILD_TESTING)
         COMMAND threads
     )
     add_test(NAME uvsample
-        COMMAND uvsample
+        COMMAND uvsample 6002
     )
     add_test(NAME version
         COMMAND hl --version

--- a/other/uvsample/UVSample.hx
+++ b/other/uvsample/UVSample.hx
@@ -37,11 +37,11 @@ class UVSample {
 		*/
 
 		var host = new sys.net.Host("localhost");
-		var port = 6001;
+		var port = Std.parseInt(Sys.args()[0]);
 
 		var totR = 0, totW = 0, totRB = 0;
 
-		log("Starting server");
+		log('Starting server on port ${port}');
 		tcp.bind(host, port);
 		tcp.listen(5, function() {
 


### PR DESCRIPTION
Since they were using the same port they failed when running in parallel