### PR TITLE
Make HL_API/HL_PRIM function have default visibility.

### DIFF
--- a/src/hl.h
+++ b/src/hl.h
@@ -154,7 +154,11 @@
 #	define EXPORT __declspec( dllexport )
 #	define IMPORT __declspec( dllimport )
 #else
+#if defined(HL_GCC) || defined(HL_CLANG)
+#	define EXPORT __attribute__((visibility("default")))
+#else
 #	define EXPORT
+#endif
 #	define IMPORT extern
 #endif
 


### PR DESCRIPTION
This is needed when (for example) building hashlink with the hxcpp build tools, since hxcpp adds `-fvisiblity=hidden`.