### PR TITLE
Mark `include` directories as third party for github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+include/*/** linguist-vendored


### PR DESCRIPTION
Marks all directories in `include` as third party libraries. This way they do not count to the overall line count of hashlink.