### PR TITLE
Fix make error related to pcre

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ HLFLAGS = -ldl
 LIBEXT = so
 LIBTURBOJPEG = -lturbojpeg
 
-PCRE_INCLUDE = -I include/pcre
+PCRE_FLAGS = -I include/pcre
 
 PCRE = include/pcre/pcre_chartables.o include/pcre/pcre_compile.o include/pcre/pcre_dfa_exec.o \
 	include/pcre/pcre_exec.o include/pcre/pcre_fullinfo.o include/pcre/pcre_globals.o \


### PR DESCRIPTION
The wrong variable was being used when building the regex part of the
standard library which was preventing compilation without a global
installation.

Only required if #515 is not merged first.