### PR TITLE
Add -lGL to sdl.hdll build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ LIBFLAGS += -L/opt/libjpeg-turbo/lib64
 endif
 
 LIBOPENAL = -lopenal
+LIBOPENGL = -lGL
 RELEASE_NAME = linux
 
 endif


### PR DESCRIPTION
This way OpenGL is correctly linked. Fixes #549.