### PR TITLE
Allow multiple file selection in ui_choose_file

### DIFF
--- a/libs/ui/ui_win.c
+++ b/libs/ui/ui_win.c
@@ -281,9 +281,11 @@ HL_PRIM vbyte *HL_NAME(ui_choose_file)( bool forSave, vdynamic *options ) {
 	wref *win = (wref*)hl_dyn_getp(options,hl_hash_utf8("window"), &hlt_abstract);
 	varray *filters = (varray*)hl_dyn_getp(options,hl_hash_utf8("filters"),&hlt_array);
 	wchar_t *fileName = (wchar_t*)hl_dyn_getp(options,hl_hash_utf8("fileName"),&hlt_bytes);
+	bool multiple = hl_dyn_geti(options,hl_hash_utf8("multiple"),&hlt_bool);
+
 	OPENFILENAME op;
-	wchar_t filterStr[1024];
-	wchar_t outputFile[1024] = {0};
+	wchar_t filterStr[2048];
+	wchar_t outputFile[2048] = {0};
 	ZeroMemory(&op, sizeof(op));
 	op.lStructSize = sizeof(op);
 	op.hwndOwner = win ? win->h : NULL;
@@ -301,12 +303,14 @@ HL_PRIM vbyte *HL_NAME(ui_choose_file)( bool forSave, vdynamic *options ) {
 		op.nFilterIndex = hl_dyn_geti(options,hl_hash_utf8("filterIndex"),&hlt_i32) + 1; // 1 based
 	}
 	if( fileName )
-		memcpy(outputFile, fileName, (wcslen(fileName)+1) * 2 );
+		memcpy(outputFile, fileName, 2048);
 	op.lpstrFile = outputFile;
 	op.nMaxFile = 1024;
 	op.lpstrInitialDir = hl_dyn_getp(options,hl_hash_utf8("directory"),&hlt_bytes);
 	op.lpstrTitle = hl_dyn_getp(options,hl_hash_utf8("title"),&hlt_bytes);
 	op.Flags |= OFN_NOCHANGEDIR;
+	if( multiple )
+		op.Flags |= OFN_ALLOWMULTISELECT | OFN_EXPLORER;
 	if( forSave ) {
 		op.Flags |= OFN_OVERWRITEPROMPT;
 		if( !GetSaveFileName(&op) )
@@ -316,7 +320,7 @@ HL_PRIM vbyte *HL_NAME(ui_choose_file)( bool forSave, vdynamic *options ) {
 		if( !GetOpenFileName(&op) )
 			return NULL;
 	}
-	return hl_copy_bytes((vbyte*)outputFile, (int)(wcslen(outputFile)+1)*2);
+	return hl_copy_bytes((vbyte*)outputFile, 2048);
 }
 
 HL_PRIM bool HL_NAME(ui_set_clipboard_text)(char* text) {

--- a/libs/ui/ui_win.c
+++ b/libs/ui/ui_win.c
@@ -305,7 +305,7 @@ HL_PRIM vbyte *HL_NAME(ui_choose_file)( bool forSave, vdynamic *options ) {
 	if( fileName )
 		memcpy(outputFile, fileName, 2048);
 	op.lpstrFile = outputFile;
-	op.nMaxFile = 1024;
+	op.nMaxFile = 2048;
 	op.lpstrInitialDir = hl_dyn_getp(options,hl_hash_utf8("directory"),&hlt_bytes);
 	op.lpstrTitle = hl_dyn_getp(options,hl_hash_utf8("title"),&hlt_bytes);
 	op.Flags |= OFN_NOCHANGEDIR;


### PR DESCRIPTION
This is one of two PRs (The other in haxe for ui.hx) to add support for multiple selection in hl.UI.chooseFile.

Both do weird things for dumb windows API reasons, so I'll explain my sins in advance. Documentation for this API can be found here: https://docs.microsoft.com/en-us/windows/win32/api/commdlg/ns-commdlg-openfilenamea (We use the widechar version, but otherwise the call pattern is identical).

To enable multi select, we really only need to set a flag. Since we just pass a simple `Dynamic` across the fence for this, I just key off a new field and set the related flag. Note we also have to set `OFN_EXPLORER` else you get the win 3.x era version of this dialogue... which is magical in its own right.

The elephant in the room though is the larger buffer, and the fact that we return the entire thing. The buffer size increase is because this API doesn't really have any mechanism for letting you ask for how many bytes you need; hence we should always oversize. And the size chosen is simply due to that being the largest buffer you can even send this API. We'll need to use a newer API if we want anything more sophisticated. 

The reason we pass the whole buffer, instead of the old behavior of just copying the length, is because the return format is null terminated. So `wcslen` will only ever return the path. The haxe commit has the untangling code for converting this data into haxe strings. This code isn't performance critical, so the extra copy shouldn't be a huge deal, and `String.fromUCS2` doesn't rely on buffer size.