### PR TITLE
skip spaces during native signature comparison

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -509,8 +509,14 @@ static void hl_module_init_natives( hl_module *m ) {
 		p = tmp;
 		append_type(&p,n->t);
 		*p++ = 0;
-		if( memcmp(sign,tmp,strlen(sign)+1) != 0 )
-			hl_fatal4("Invalid signature for function %s@%s : %s required but %s found in hdll",n->lib,n->name,tmp,sign);
+                for(int i = 0, j = 0; i < strlen(sign)+1; i++) {
+                     if (sign[i] == tmp[j]) {
+                          j++;
+                     } else if (sign[i] != ' ') {
+                          hl_fatal4("Invalid signature for function %s@%s : %s required but %s found in hdll",n->lib,n->name,tmp,sign);
+                          break;
+                     }
+                }
 	}
 }
 


### PR DESCRIPTION
The default code formatter for VSCode C++ will introduce a bug:
```c++
    // This
    DEFINE_PRIM(_ABSTRACT(state*), init, _NO_ARGS);
    // becomes this
    DEFINE_PRIM(_ABSTRACT(state *), init, _NO_ARGS);
```

```
src/module.c(513) : FATAL ERROR : Invalid signature for function hlcef@shutdown : PXstate*__v required but PXstate *__v found in hdll
```

This isn't a problem with hashlink, but it would be good to handle spaces.

BTW is there any way to add tests? It looks like CI only builds the project, right?