### PR TITLE
Avoid redefining `_GNU_SOURCE`.

### DIFF
--- a/src/hl.h
+++ b/src/hl.h
@@ -53,7 +53,9 @@
 
 #if defined(linux) || defined(__linux__)
 #	define HL_LINUX
-#	define _GNU_SOURCE
+#	ifndef _GNU_SOURCE
+#		define _GNU_SOURCE
+#	endif
 #endif
 
 #if defined(HL_IOS) || defined(HL_ANDROID) || defined(HL_TVOS)


### PR DESCRIPTION
This isn't an issue when compiling HashLink alone, but causes warnings when compiling it alongside other libraries [such as SDL](https://github.com/libsdl-org/SDL/blob/f0566702c5e4c3522148fca6c65e83fb57326ddb/src/SDL_internal.h#L24-L27).

The warnings don't interfere with compilation, but given that the solution is so simple, why not fix them?