### PR TITLE
[CI] Go back to ubuntu 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
         include:
           - target: linux
-            runner: ubuntu-18.04
+            runner: ubuntu-20.04
             haxe_nightly_dir: linux64
             archive_ext: tar.gz
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,9 @@ jobs:
           - target: linux
             build_system: vs2019
 
+          - target: linux
+            architecture: 32
+
           - target: darwin
             build_system: vs2019
 
@@ -356,7 +359,7 @@ jobs:
           --prerelease \
           --title "HashLink Nightly Build" \
           "artifact/hashlink-${short_commit}-darwin.tar.gz#hashlink-latest-darwin.tar.gz" \
-          "artifact/hashlink-${short_commit}-linux-i386.tar.gz#hashlink-latest-linux-i386.tar.gz" \
+          # "artifact/hashlink-${short_commit}-linux-i386.tar.gz#hashlink-latest-linux-i386.tar.gz" \
           "artifact/hashlink-${short_commit}-linux-amd64.tar.gz#hashlink-latest-linux-amd64.tar.gz" \
           "artifact/hashlink-${short_commit}-win32.zip#hashlink-latest-win32.zip" \
           "artifact/hashlink-${short_commit}-win64.zip#hashlink-latest-win64.zip"


### PR DESCRIPTION
Ubuntu 18.04 is not available anymore on github actions.
I suppose we could rewrite it all using docker images, but would that be worth it?

As far as I understand, this means:
 * no more 32bit linux releases; support for which seem to have been dropped at most places
 * ubuntu 18 (which EOL is in a month or so) users will need to build from source or use an older release
 * anything else in a worse state than last month with ubuntu 18?

cc @Apprentice-Alchemist @tobil4sk  

Past work that this pretty much cancels: #529 #533 