### PR TITLE
Fix linker warnings from pcre

### DIFF
--- a/src/std/regexp.c
+++ b/src/std/regexp.c
@@ -21,6 +21,7 @@
  */
 #include <hl.h>
 
+#define PCRE2_STATIC
 #include <pcre2.h>
 
 typedef struct _ereg ereg;


### PR DESCRIPTION
e.g.

LINK : warning LNK4217: symbol 'pcre2_compile_16' defined in 'pcre2_compile.obj' is imported by 'regexp.obj' in function 'hl_regexp_new_options' [D:\a\hashlink\hashlink\libhl.vcxproj]