### PR TITLE
Prevent hl_thread_id throw error even when we can't get a tid

### DIFF
--- a/src/std/thread.c
+++ b/src/std/thread.c
@@ -812,7 +812,6 @@ HL_PRIM int hl_thread_id() {
 #elif defined(SYS_gettid) && !defined(HL_TVOS)
 	return syscall(SYS_gettid);
 #else
-	hl_error("hl_thread_id() not available for this platform");
 	return -1;
 #endif
 }


### PR DESCRIPTION
In some systems (target language C), we'll fall under the [else condition of hl_thread_id](https://github.com/HaxeFoundation/hashlink/blob/master/src/std/thread.c#L815), which will throw an exception till now. It will prevent the use of multithread in these systems (called by hlc_main->hl_register_thread->hl_thread_id) even if they support posix. This is not an fatal error if we do not need `hl_thread_set_name` and `hl_thread_get_name`.
This commit remove the hl_error.