### PR TITLE
Remove deprecated use of @:enum abstract

### DIFF
--- a/libs/directx/dx/Cursor.hx
+++ b/libs/directx/dx/Cursor.hx
@@ -2,7 +2,7 @@ package dx;
 
 private typedef CursorPtr = hl.Abstract<"dx_cursor">;
 
-@:enum abstract CursorKind(Int) {
+enum abstract CursorKind(Int) {
 	var Arrow = 32512;
     var IBeam = 32513;
     var Wait = 32514;

--- a/libs/directx/dx/Driver.hx
+++ b/libs/directx/dx/Driver.hx
@@ -65,7 +65,7 @@ abstract DxBool(Int) {
 	@:from static function fromBool( b : Bool ) : DxBool return cast b;
 }
 
-@:enum abstract DriverInitFlags(Int) {
+enum abstract DriverInitFlags(Int) {
 	var None = 0;
 	var SingleThread = 1;
 	var DebugLayer = 2;
@@ -79,14 +79,14 @@ abstract DxBool(Int) {
 	@:op(a | b) static function or(a:DriverInitFlags, b:DriverInitFlags) : DriverInitFlags;
 }
 
-@:enum abstract ResourceUsage(Int) {
+enum abstract ResourceUsage(Int) {
 	var Default = 0;
 	var Immutable = 1;
 	var Dynamic = 2;
 	var Staging = 3;
 }
 
-@:enum abstract ResourceBind(Int) {
+enum abstract ResourceBind(Int) {
 	var None = 0;
 	var VertexBuffer = 1;
 	var IndexBuffer = 2;
@@ -101,14 +101,14 @@ abstract DxBool(Int) {
 	@:op(a | b) static function or(a:ResourceBind, b:ResourceBind) : ResourceBind;
 }
 
-@:enum abstract ResourceAccess(Int) {
+enum abstract ResourceAccess(Int) {
 	var None = 0;
 	var CpuWrite = 0x10000;
 	var CpuRead = 0x20000;
 	@:op(a | b) static function or(a:ResourceAccess, b:ResourceAccess) : ResourceAccess;
 }
 
-@:enum abstract ResourceMisc(Int) {
+enum abstract ResourceMisc(Int) {
 	var None = 0;
 	var GenerateMips = 1;
 	var Shared = 2;
@@ -130,7 +130,7 @@ abstract DxBool(Int) {
 	@:op(a | b) static function or(a:ResourceMisc, b:ResourceMisc) : ResourceMisc;
 }
 
-@:enum abstract ShaderFlags(Int) {
+enum abstract ShaderFlags(Int) {
 	var None = 0;
 	var Debug = 0x1;
 	var SkipValidation = 0x2;
@@ -157,7 +157,7 @@ abstract DxBool(Int) {
 	@:op(a | b) static function or(a:ShaderFlags, b:ShaderFlags) : ShaderFlags;
 }
 
-@:enum abstract PrimitiveTopology(Int) {
+enum abstract PrimitiveTopology(Int) {
 	var Undefined = 0;
 	var PointList = 1;
 	var LineList = 2;
@@ -170,7 +170,7 @@ abstract DxBool(Int) {
 	static inline function controlPointPatchList(count:Int) : PrimitiveTopology return cast (count + 32);
 }
 
-@:enum abstract DisassembleFlags(Int) {
+enum abstract DisassembleFlags(Int) {
 	var None = 0;
 	var EnableColorCode = 1;
 	var EnableDefaultValuePrints = 2;
@@ -183,7 +183,7 @@ abstract DxBool(Int) {
 	@:op(a | b) static function or(a:DisassembleFlags, b:DisassembleFlags) : DisassembleFlags;
 }
 
-@:enum abstract LayoutClassification(Int) {
+enum abstract LayoutClassification(Int) {
 	var PerVertexData = 0;
 	var PerInstanceData = 1;
 }
@@ -201,7 +201,7 @@ class LayoutElement {
 	}
 }
 
-@:enum abstract ResourceDimension(Int) {
+enum abstract ResourceDimension(Int) {
 	var Unknown = 0;
 	var Buffer = 1;
 	var Texture1D = 2;
@@ -239,12 +239,12 @@ class RenderTargetDesc {
 	inline function set_elementCount(m) return firstSlice = m;
 }
 
-@:enum abstract FillMode(Int) {
+enum abstract FillMode(Int) {
 	public var WireFrame = 2;
 	public var Solid = 3;
 }
 
-@:enum abstract CullMode(Int) {
+enum abstract CullMode(Int) {
 	public var None = 1;
 	public var Front = 2;
 	public var Back = 3;
@@ -288,7 +288,7 @@ class Texture2dDesc {
 	}
 }
 
-@:enum abstract ComparisonFunc(Int) {
+enum abstract ComparisonFunc(Int) {
 	var Never = 1;
 	var Less = 2;
 	var Equal = 3;
@@ -299,7 +299,7 @@ class Texture2dDesc {
 	var Always = 8;
 }
 
-@:enum abstract StencilOp(Int) {
+enum abstract StencilOp(Int) {
 	var Keep = 1;
 	var Zero = 2;
 	var Replace = 3;
@@ -350,7 +350,7 @@ class DepthStencilDesc {
 	}
 }
 
-@:enum abstract Blend(Int) {
+enum abstract Blend(Int) {
 	var Zero = 1; // (;_;)
 	var One = 2;
 	var SrcColor = 3;
@@ -370,7 +370,7 @@ class DepthStencilDesc {
 	var InvSrc1Alpha = 19;
 }
 
-@:enum abstract BlendOp(Int) {
+enum abstract BlendOp(Int) {
 	var Add = 1;
 	var Subtract = 2;
 	var RevSubstract = 3;
@@ -394,7 +394,7 @@ class RenderTargetBlendDesc {
 	}
 }
 
-@:enum abstract Filter(Int) {
+enum abstract Filter(Int) {
 	var MinMagMipPoint = 0;
 	var MinMagPointMipLinear = 0x1;
 	var MinPointMagLinearMipPoint = 0x4;
@@ -433,7 +433,7 @@ class RenderTargetBlendDesc {
 	var MaximumAnisotropic = 0x1d5;
 }
 
-@:enum abstract AddressMode(Int) {
+enum abstract AddressMode(Int) {
 	var Wrap = 1;
 	var Mirror = 2;
 	var Clamp = 3;
@@ -472,7 +472,7 @@ class ShaderResourceViewDesc {
 	}
 }
 
-@:enum abstract PresentFlags(Int) {
+enum abstract PresentFlags(Int) {
 	var None = 0;
 	var Test = 1;
 	var DoNotSequence = 2;

--- a/libs/directx/dx/Format.hx
+++ b/libs/directx/dx/Format.hx
@@ -1,6 +1,6 @@
 package dx;
 
-@:enum abstract Format(Int) {
+enum abstract Format(Int) {
 	var UNKNOWN                     = 0;
 	var R32G32B32A32_TYPELESS       = 1;
 	var R32G32B32A32_FLOAT          = 2;

--- a/libs/directx/dx/Resource.hx
+++ b/libs/directx/dx/Resource.hx
@@ -1,6 +1,6 @@
 package dx;
 
-@:enum abstract MapType(Int) {
+enum abstract MapType(Int) {
 	var Read = 1;
 	var Write = 2;
 	var ReadWrite = 3;

--- a/libs/directx/dx/Window.hx
+++ b/libs/directx/dx/Window.hx
@@ -18,7 +18,7 @@ typedef DisplaySetting = {
 	framerate : Int
 }
 
-@:enum abstract DisplayMode(Int) {
+enum abstract DisplayMode(Int) {
 	var Windowed = 0;
 	var Fullscreen = 1;
 	var Borderless = 2;

--- a/libs/sdl/sdl/Cursor.hx
+++ b/libs/sdl/sdl/Cursor.hx
@@ -2,7 +2,7 @@ package sdl;
 
 private typedef CursorPtr = hl.Abstract<"sdl_cursor">;
 
-@:enum abstract CursorKind(Int) {
+enum abstract CursorKind(Int) {
 	var Arrow = 0;
     var IBeam = 1;
     var Wait = 2;

--- a/libs/sdl/sdl/Event.hx
+++ b/libs/sdl/sdl/Event.hx
@@ -20,7 +20,7 @@ package sdl;
 	}
 }
 
-@:enum abstract EventType(Int) {
+enum abstract EventType(Int) {
 	var Quit		= 0;
 	var MouseMove	= 1;
 	var MouseLeave	= 2;
@@ -48,7 +48,7 @@ package sdl;
 	var JoystickRemoved		= 306;
 }
 
-@:enum abstract WindowStateChange(Int) {
+enum abstract WindowStateChange(Int) {
 	var Show	= 0;
 	var Hide	= 1;
 	var Expose	= 2;

--- a/libs/sdl/sdl/Sdl.hx
+++ b/libs/sdl/sdl/Sdl.hx
@@ -235,8 +235,7 @@ class Sdl {
 	}
 }
 
-@:enum
-abstract SDLHint(String) from String to String {
+enum abstract SDLHint(String) from String to String {
 
 	var SDL_HINT_FRAMEBUFFER_ACCELERATION =                 "SDL_FRAMEBUFFER_ACCELERATION";
 	var SDL_HINT_RENDER_DRIVER =                            "SDL_RENDER_DRIVER";

--- a/libs/sdl/sdl/Window.hx
+++ b/libs/sdl/sdl/Window.hx
@@ -4,7 +4,7 @@ typedef WinPtr = hl.Abstract<"sdl_window">;
 private typedef GLContext = hl.Abstract<"sdl_gl">;
 typedef DisplayHandle = Null<Int>;
 
-@:enum abstract DisplayMode(Int) {
+enum abstract DisplayMode(Int) {
 	var Windowed = 0;
 	var Fullscreen = 1;
 	var Borderless = 2;

--- a/other/memory/Block.hx
+++ b/other/memory/Block.hx
@@ -27,7 +27,7 @@ abstract Pointer(haxe.Int64) {
 
 }
 
-@:enum abstract PageKind(Int) {
+enum abstract PageKind(Int) {
 	var PDynamic = 0;
 	var PRaw = 1;
 	var PNoPtr = 2;


### PR DESCRIPTION
Although the changes are straight forward, I didn't manage to test them properly, because I didn't figure out how to add the repo as the git version to use for hlsdl in particular.
