### PR TITLE
Allow skipping lines without error on memory tool

### DIFF
--- a/other/memory/Memory.hx
+++ b/other/memory/Memory.hx
@@ -892,6 +892,8 @@ class Memory {
 				if( v != null )
 					m.maxLines = Std.parseInt(v);
 				Sys.println(m.maxLines == 0 ? "Lines limit disabled" : m.maxLines + " maximum lines displayed");
+			case null:
+				Sys.println("");
 			default:
 				Sys.println("Unknown command " + cmd);
 			}


### PR DESCRIPTION
Pressing enter on empty prompts in the memory tool will not display "Unknown command" anymore