### PR TITLE
Fix uchar on macOS.

### DIFF
--- a/src/hl.h
+++ b/src/hl.h
@@ -244,10 +244,6 @@ HL_API int uvszprintf( uchar *out, int out_size, const uchar *fmt, va_list argli
 #	define utoi(s,end)	wcstol(s,end,10)
 #	define ucmp(a,b)	wcscmp(a,b)
 #	define utostr(out,size,str) wcstombs(out,str,size)
-#elif defined(HL_MAC)
-typedef uint16_t uchar;
-#	undef USTR
-#	define USTR(str)	u##str
 #else
 #	include <stdarg.h>
 #if defined(HL_IOS) || defined(HL_TVOS) || defined(HL_MAC)


### PR DESCRIPTION
Defining uchar as `uint16_t` causes errors when using unicode literals in C++,
because in C++ `char16_t` is not the same type as `uint16_t`.