### PR TITLE
Fix deprecated @:enum metadata in Event.hx

### DIFF
--- a/libs/directx/dx/Event.hx
+++ b/libs/directx/dx/Event.hx
@@ -18,7 +18,7 @@ package dx;
 	}
 }
 
-@:enum abstract EventType(Int) {
+enum abstract EventType(Int) {
 	var Quit		= 0;
 	var MouseMove	= 1;
 	var MouseLeave	= 2;
@@ -31,7 +31,7 @@ package dx;
 	var TextInput	= 9;
 }
 
-@:enum abstract WindowStateChange(Int) {
+enum abstract WindowStateChange(Int) {
 	var Show	= 0;
 	var Hide	= 1;
 	var Expose	= 2;


### PR DESCRIPTION
Looks like these got missed in be64c2c86ad47b75ba0d1e5d72bbac443e9f3b75