### PR TITLE
Make macOS CI green again.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
             archive_ext: tar.gz
 
           - target: darwin
-            runner: macos-11
+            runner: macos-12
             haxe_nightly_dir: mac
             archive_ext: tar.gz
 
@@ -107,8 +107,11 @@ jobs:
             ;;
 
           darwin*)
+            brew list --formula | xargs brew uninstall --force --ignore-dependencies
+            brew list --cask | xargs brew uninstall --force --ignore-dependencies
             brew update
             brew bundle
+            brew link mbedtls@2 --force # needed for CMake
             ;;
 
           windows*)

--- a/Brewfile
+++ b/Brewfile
@@ -7,7 +7,7 @@ brew "sdl2"
 brew "libogg"
 brew "libvorbis"
 brew "openal-soft"
-brew "mbedtls@2", link: true
+brew "mbedtls@2"
 brew "libuv"
 brew "openssl"
 brew "sqlite"


### PR DESCRIPTION
- mbedtls@2 is keg-only, so it needs to be explicitly force-linked
- Switch to macOS 12, Homebrew doesn't support 11 anymore
   - Remove all pre-installed homebrew packages to prevent any issues during brew bundle.
   (This is probably overkill, but I do not have a better fix for now. Will send a follow-up PR if I find a better solution.)