### PR TITLE
Retry interrupted std stream read/write calls.

### DIFF
--- a/src/std/process.c
+++ b/src/std/process.c
@@ -187,7 +187,10 @@ HL_PRIM int hl_process_stdout_read( vprocess *p, vbyte *str, int pos, int len ) 
 		return -1;
 	return nbytes;
 #	else
-	int nbytes = read(p->oread,str+pos,len);
+	int nbytes;
+	do {
+		nbytes = read(p->oread,str+pos,len);
+	} while (nbytes == -1 && errno == EINTR);
 	if( nbytes <= 0 )
 		return -1;
 	return nbytes;
@@ -201,7 +204,10 @@ HL_PRIM int hl_process_stderr_read( vprocess *p, vbyte *str, int pos, int len ) 
 		return -1;
 	return nbytes;
 #	else
-	int nbytes = read(p->eread,str+pos,len);
+	int nbytes;
+	do {
+		nbytes = read(p->eread,str+pos,len);
+	} while (nbytes == -1 && errno == EINTR);
 	if( nbytes <= 0 )
 		return -1;
 	return nbytes;
@@ -215,7 +221,10 @@ HL_PRIM int hl_process_stdin_write( vprocess *p, vbyte *str, int pos, int len ) 
 		return -1;
 	return nbytes;
 #	else
-	int nbytes = write(p->iwrite,str+pos,len);
+	int nbytes;
+	do {
+		nbytes = write(p->iwrite,str+pos,len);
+	} while (nbytes == -1 && errno == EINTR);
 	if( nbytes < 0 )
 		return -1;
 	return nbytes;


### PR DESCRIPTION
The Hashlink profiler causes some Linux system calls to be interrupted. Previously, error handling was added for `std/file.c` read/write operations. However, the read/write calls made by sys.io.Process use instead the unistd read/write functions which are also [affected by the interrupts](https://github.com/HaxeFoundation/hashlink/issues/650).

This pull request extends the [previously introduced error handling](https://github.com/HaxeFoundation/hashlink/commit/775d53e7c53508bac784cd05e9bd96278b4f5ef7) also to the unistd read/write calls in `std/process.c`.

The behaviour can be tested with the following program, which uses the stdout, stderr and stdin streams via sys.io.Process:

```haxe
import sys.io.Process;

class Main
{
    static public function main():Void
    {
        var cat = new Process('cat');
        cat.stdin.writeString('Text to stdout\n');
        trace(cat.stdout.readLine());
        cat = new Process('cat 1>&2');
        cat.stdin.writeString('Text to stderr\n');
        trace(cat.stderr.readLine());
    }
}
```

Previously, when running with the profiler `hl --profile 1000 test.hl` the test program fails with the exception:

```
Uncaught exception: Eof
Called from haxe.io.Input.readLine(.../haxe-4.3.3-linux64/haxe_20231117191750_de28889/std/haxe/io/Input.hx:189)
Called from $Main.main(Main.hx:9)
Called from .init(?:1)
```

With the proposed changes the test program runs normally and can be profiled.