### PR TITLE
Add get live objects

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -1448,7 +1448,7 @@ HL_API void hl_gc_dump_memory( const char *filename ) {
 typedef struct {
 	hl_type *t;
 	int count;
-	int page_kind;
+	int page_kinds;
 	varray *arr;
 	int index;
 } gc_live_obj;
@@ -1466,7 +1466,7 @@ static void gc_count_live_block( void *block, int size ) {
 }
 
 static void gc_count_live_page( gc_pheader *p, int private_data ) {
-	if( (1 << p->page_kind) & live_obj.page_kind )
+	if( (1 << p->page_kind) & live_obj.page_kinds )
 		gc_iter_live_blocks(p, gc_count_live_block);
 }
 
@@ -1478,9 +1478,9 @@ static int hl_gc_get_live_objects( hl_type *t, varray *arr ) {
 
 	live_obj.t = t;
 	live_obj.count = 0;
-	live_obj.page_kind = (1 << MEM_KIND_DYNAMIC) + (1 << MEM_KIND_NOPTR);
+	live_obj.page_kinds = (1 << MEM_KIND_DYNAMIC) + (1 << MEM_KIND_NOPTR);
 	if (t->kind == HOBJ) {
-		live_obj.page_kind = hl_get_obj_rt(t)->hasPtr ? 1 << MEM_KIND_DYNAMIC : 1 << MEM_KIND_NOPTR;
+		live_obj.page_kinds = hl_get_obj_rt(t)->hasPtr ? 1 << MEM_KIND_DYNAMIC : 1 << MEM_KIND_NOPTR;
 	}
 	live_obj.arr = arr;
 	live_obj.index = 0;

--- a/src/gc.c
+++ b/src/gc.c
@@ -1479,7 +1479,7 @@ static int hl_gc_get_live_objects( hl_type *t, varray *arr ) {
 	live_obj.t = t;
 	live_obj.count = 0;
 	live_obj.page_kinds = (1 << MEM_KIND_DYNAMIC) + (1 << MEM_KIND_NOPTR);
-	if (t->kind == HOBJ) {
+	if( t->kind == HOBJ ) {
 		live_obj.page_kinds = hl_get_obj_rt(t)->hasPtr ? 1 << MEM_KIND_DYNAMIC : 1 << MEM_KIND_NOPTR;
 	}
 	live_obj.arr = arr;

--- a/src/gc.c
+++ b/src/gc.c
@@ -1448,17 +1448,17 @@ HL_API void hl_gc_dump_memory( const char *filename ) {
 static int live_obj_count;
 static hl_type *live_obj_t;
 
-static void gc_count_live_block(void *block, int size) {
+static void gc_count_live_block( void *block, int size ) {
 	hl_type *t = *(hl_type **)block;
-	if (t == live_obj_t)
+	if( t == live_obj_t )
 		live_obj_count += 1;
 }
 
-static void gc_count_live_page(gc_pheader *p, int private_data) {
+static void gc_count_live_page( gc_pheader *p, int private_data ) {
 	gc_iter_live_blocks(p, gc_count_live_block);
 }
 
-static int hl_gc_count_live_objects(hl_type *t) {
+static int hl_gc_count_live_objects( hl_type *t ) {
 	gc_global_lock(true);
 	gc_stop_world(true);
 	gc_mark();


### PR DESCRIPTION
For https://github.com/HaxeFoundation/hashlink/issues/656 , usage (API should be in haxe someday with hl_ver >= 1.15.0):

```haxe
class MemoryTools {
	/**
		Count live objects of a given class and get at most `maxCount` elements in an array.
	**/	
	public static function getLiveObjects(cl : Class<Dynamic>, maxCount : Int = 0) {
		var arr = new hl.NativeArray<Dynamic>(maxCount);
		var count = _getLiveObjects(cast(cl,hl.BaseType).__type__, arr);
		var objs = new Array<Dynamic>();
		for (i in 0...maxCount) {
			if (arr[i] == null) break;
			objs.push(arr[i]);
		}
		return { count : count, objs : objs };
	}

	@:hlNative("std", "gc_get_live_objects")
	static function _getLiveObjects(type : hl.Type, arr : hl.NativeArray<Dynamic>) : Int { return 0; }
}
```

Then,

```haxe
MemoryTools.getLiveObjects(h2d.col.Point.PointImpl, 5);
MemoryTools.getLiveObjects(std.Type.resolveClass("h2d.col.PointImpl"), 5);
```

However it count only exactly the same type (no child class instance, no abstract).