### PR TITLE
Fix UI8 assign on Linux

### DIFF
--- a/src/jit.c
+++ b/src/jit.c
@@ -1135,8 +1135,9 @@ static preg *copy( jit_ctx *ctx, preg *to, preg *from, int size ) {
 					op32(ctx,SHR,to,pconst(&p,24));
 					break;
 				}
-			} else if( !is_reg8(from) ) {
-				preg *r = alloc_reg(ctx, RCPU_CALL);				
+			}
+			if( !is_reg8(from) ) {
+				preg *r = alloc_reg(ctx, RCPU_8BITS);
 				op32(ctx, MOV, r, from);
 				RUNLOCK(r);
 				op32(ctx,MOV8,to,r);


### PR DESCRIPTION
Fixes https://github.com/HaxeFoundation/hashlink/issues/142 , fixes https://github.com/HaxeFoundation/hashlink/issues/658 for me without breaking our game on Linux (Ubuntu 22.04).

I'm not very sure what I'm doing, so here is some description:
I found that Linux & Windows have different set of CPU registers (if I use the same cpu set, I have segfault)
https://github.com/HaxeFoundation/hashlink/blob/8bc5f8f0d21c38805ca3457e5298a27d96c396ad/src/jit.c#L227-L239

Esi, Edi are used in Linux, however they are not 8 bit register (remove the id check on RCPU fixes the issues, but will make our game to exit "normally" without actually run and I don't understand why)
https://github.com/HaxeFoundation/hashlink/blob/8bc5f8f0d21c38805ca3457e5298a27d96c396ad/src/jit.c#L542-L544

The UI8 op failed during a MOV8 (called by copy-copyfrom), with a RCPU id = 1, b RCPU id = 7 (Edi)
https://github.com/HaxeFoundation/hashlink/blob/8bc5f8f0d21c38805ca3457e5298a27d96c396ad/src/jit.c#L552-L554

So I move the `!is_reg8(from)` also for the case when to.kind = RCPU. I also force the Reg choice to `RCPU_8BITS` because by the name it make sens, but it seems not necessary for the fix.