### PR TITLE
Add support for SDL_GetGlobalMouseState

### DIFF
--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -474,6 +474,10 @@ HL_PRIM bool HL_NAME(get_window_grab)(SDL_Window* window) {
 	return SDL_GetWindowGrab(window);
 }
 
+HL_PRIM int HL_NAME(get_global_mouse_state)(int* x, int* y) {
+	return SDL_GetGlobalMouseState(x, y);
+}
+
 HL_PRIM const char *HL_NAME(detect_keyboard_layout)() {
 	char q = SDL_GetKeyFromScancode(SDL_SCANCODE_Q);
 	char w = SDL_GetKeyFromScancode(SDL_SCANCODE_W);
@@ -508,6 +512,7 @@ DEFINE_PRIM(_I32, warp_mouse_global, _I32 _I32);
 DEFINE_PRIM(_VOID, warp_mouse_in_window, TWIN _I32 _I32);
 DEFINE_PRIM(_VOID, set_window_grab, TWIN _BOOL);
 DEFINE_PRIM(_BOOL, get_window_grab, TWIN);
+DEFINE_PRIM(_I32, get_global_mouse_state, _REF(_I32) _REF(_I32));
 DEFINE_PRIM(_BYTES, detect_keyboard_layout, _NO_ARG);
 DEFINE_PRIM(_BOOL, hint_value, _BYTES _BYTES);
 

--- a/libs/sdl/sdl/Sdl.hx
+++ b/libs/sdl/sdl/Sdl.hx
@@ -220,6 +220,7 @@ class Sdl {
 		return 0;
 	}
 
+	@:hlNative("?sdl", "get_global_mouse_state")
 	public static function getGlobalMouseState( x : hl.Ref<Int>, y : hl.Ref<Int> ) : Int {
 		return 0;
 	}

--- a/libs/sdl/sdl/Sdl.hx
+++ b/libs/sdl/sdl/Sdl.hx
@@ -220,6 +220,10 @@ class Sdl {
 		return 0;
 	}
 
+	public static function getGlobalMouseState( x : hl.Ref<Int>, y : hl.Ref<Int> ) : Int {
+		return 0;
+	}
+
 	static function detect_keyboard_layout() : hl.Bytes {
 		return null;
 	}


### PR DESCRIPTION
This allows us to track drag/resize movements that go outside the window; fixing the issue where dragging too fast will lose a handle on the window. The motivation behind this feature is to support ImGui multi-window viewports

Viewports will function without this, but moving/resizing windows sucks, as the mouse can move more than the title bar's width per frame, causing it to lose track of the window and "drop" it.

Unsure if there's a parallel to this in DX, but we can't use that backend currently anyway since it lacks single driver multi window support at the moment. Given this limitation I'm unsure there's any value in adding a similar function or common routing in hldx, but I can do this work if it's necessary for merge.