### PR TITLE
Fix multiple instances of undefined behaviour and crashes when using ubsan

### DIFF
--- a/src/code.c
+++ b/src/code.c
@@ -83,7 +83,7 @@ static int hl_read_i32( hl_reader *r ) {
 	b = r->b[r->pos++];
 	c = r->b[r->pos++];
 	d = r->b[r->pos++];
-	return a | (b<<8) | (c<<16) | (d<<24);
+	return (unsigned)a | ((unsigned)b<<8) | ((unsigned)c<<16) | ((unsigned)d<<24);
 }
 
 static int hl_read_index( hl_reader *r ) {

--- a/src/hl.h
+++ b/src/hl.h
@@ -199,6 +199,7 @@
 #endif
 
 typedef intptr_t int_val;
+typedef uintptr_t uint_val;
 typedef long long int64;
 typedef unsigned long long uint64;
 

--- a/src/jit.c
+++ b/src/jit.c
@@ -2537,7 +2537,6 @@ static void jit_hl2c( jit_ctx *ctx ) {
 	// and pack and pass the args to callback_hl2c
 	preg p;
 	int jfloat1, jfloat2, jexit;
-	hl_type_fun *ft = NULL;
 	int size;
 #	ifdef HL_64
 	preg *cl = REG_AT(CALL_REGS[0]);
@@ -4124,7 +4123,6 @@ int hl_jit_function( jit_ctx *ctx, hl_module *m, hl_function *f ) {
 				int size, jenter, jtrap;
 				int offset = 0;
 				int trap_size = (sizeof(hl_trap_ctx) + 15) & 0xFFF0;
-				hl_trap_ctx *t = NULL;
 #				ifndef HL_THREADS
 				if( tinf == NULL ) tinf = hl_get_thread(); // single thread
 #				endif
@@ -4206,7 +4204,6 @@ int hl_jit_function( jit_ctx *ctx, hl_module *m, hl_function *f ) {
 		case OEndTrap:
 			{
 				int trap_size = (sizeof(hl_trap_ctx) + 15) & 0xFFF0;
-				hl_trap_ctx *tmp = NULL;
 				preg *addr,*r;
 				int offset;
 				if (!tinf) {

--- a/src/module.c
+++ b/src/module.c
@@ -622,7 +622,11 @@ static void hl_module_init_constant( hl_module *m, hl_constant *c ) {
 static void hl_module_add( hl_module *m ) {
 	hl_module **old_modules = cur_modules;
 	hl_module **new_modules = (hl_module**)malloc(sizeof(void*)*(modules_count + 1));
-	memcpy(new_modules, old_modules, sizeof(void*)*modules_count);
+
+	if(old_modules) { 
+		memcpy(new_modules, old_modules, sizeof(void*)*modules_count);
+	}
+
 	new_modules[modules_count] = m;
 	cur_modules = new_modules;
 	modules_count++;

--- a/src/std/bytes.c
+++ b/src/std/bytes.c
@@ -32,7 +32,9 @@ HL_PRIM vbyte *hl_copy_bytes( const vbyte *ptr, int size ) {
 }
 
 HL_PRIM void hl_bytes_blit( char *dst, int dpos, char *src, int spos, int len ) {
-	memmove(dst + dpos,src+spos,len);
+	if(dst && src) {
+		memmove(dst + dpos,src + spos,len);
+	}
 }
 
 HL_PRIM int hl_bytes_compare( vbyte *a, int apos, vbyte *b, int bpos, int len ) {
@@ -143,7 +145,9 @@ HL_PRIM int hl_bytes_rfind( vbyte *where, int len, vbyte *which, int wlen ) {
 }
 
 HL_PRIM void hl_bytes_fill( vbyte *bytes, int pos, int len, int value ) {
-	memset(bytes+pos,value,len);
+	if(bytes) {
+		memset(bytes+pos,value,len);
+	}
 }
 
 

--- a/src/std/debug.c
+++ b/src/std/debug.c
@@ -349,7 +349,7 @@ HL_API void *hl_debug_read_register( int pid, int thread, int reg, bool is64 ) {
 		// peek FP ptr
 		char *addr = (char*)ptrace(PTRACE_PEEKUSER,thread,get_reg(-1),0);
 		void *out = NULL;
-		hl_debug_read(pid, addr + (-((int_val)r)-1), (vbyte*)&out, sizeof(void*));
+		hl_debug_read(pid, (unsigned char*)(addr + (-((int_val)r)-1)), (vbyte*)&out, sizeof(void*));
 		return out;
 	}
 	return (void*)ptrace(PTRACE_PEEKUSER,thread,r,0);

--- a/src/std/maps.c
+++ b/src/std/maps.c
@@ -46,7 +46,11 @@ typedef struct {
 
 static void hl_freelist_resize( hl_free_list *f, int newsize ) {
 	hl_free_bucket *buckets = (hl_free_bucket*)hl_gc_alloc_noptr(sizeof(hl_free_bucket)*newsize);
-	memcpy(buckets,f->buckets,f->head * sizeof(hl_free_bucket));
+	
+	if(f->buckets) {
+		memcpy(buckets,f->buckets,f->head * sizeof(hl_free_bucket));
+	}
+	
 	f->buckets = buckets;
 	f->nbuckets = newsize;
 }

--- a/src/std/random.c
+++ b/src/std/random.c
@@ -83,7 +83,7 @@ HL_PRIM rnd *hl_rnd_init_system() {
 	time = 4644546;
 	pid = 0;
 #endif
-	hl_rnd_set_seed(r,time ^ (pid | (pid << 16)));
+	hl_rnd_set_seed(r,time ^ ((unsigned)pid | ((unsigned)pid << 16)));
 	return r;
 }
 


### PR DESCRIPTION
While compiling with [zig cc](https://ziglang.org/learn/overview/#zig-is-also-a-c-compiler) I encountered crashes due to undefined behaviour (It enables ubsan by default in debug/safe builds). This PR aims to fix some code which causes ub

Some of the fixes include:
 * Avoid passing NULL to src or dest in memcpy()
 * Avoid incrementing/decrementing a NULL pointer
 * Avoid incrementing a pointer by 0
 * Avoid doing signed bit shifting by casting to unsigned first