### PR TITLE
Fix SDL failing to initialize on desktop (C4554)

### DIFF
--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -521,11 +521,11 @@ DEFINE_PRIM(_BOOL, hint_value, _BYTES _BYTES);
 
 HL_PRIM SDL_Window *HL_NAME(win_create_ex)(int x, int y, int width, int height, int sdlFlags) {
 	// force window to match device resolution on mobile
-	if (sdlFlags & (
+	if ((sdlFlags & (
 #ifdef HL_MAC
 		SDL_WINDOW_METAL | 
 #endif
-		SDL_WINDOW_VULKAN ) == 0) {
+		SDL_WINDOW_VULKAN )) == 0) {
 		sdlFlags |= SDL_WINDOW_OPENGL;
 	}
 


### PR DESCRIPTION
This is an operator precedence bug introduced in https://github.com/HaxeFoundation/hashlink/commit/1d54fc5734757d7e050bae0d0ce80d28d9d01121, and due to changes in defaults prevents SDL from working on PC.

As written, with C++ operator precedence, this check does not do what you'd expect and `SDL_WINDOW_OPENGL` never gets set. This change simply adds missing parenthesis to force the bitwise ops to resolve before equality checks.