### PR TITLE
Fix debug Linux

### DIFF
--- a/src/std/debug.c
+++ b/src/std/debug.c
@@ -25,6 +25,7 @@
 #	include <sys/wait.h>
 #	include <sys/user.h>
 #	include <signal.h>
+#	include <errno.h>
 #	define USE_PTRACE
 #endif
 
@@ -84,6 +85,7 @@ HL_API bool hl_debug_stop( int pid ) {
 #	elif defined(MAC_DEBUG)
 	return mdbg_session_detach(pid);
 #	elif defined(USE_PTRACE)
+	kill(pid, SIGTRAP); // DETACH needs ptrace-stop
 	return ptrace(PTRACE_DETACH,pid,0,0) >= 0;
 #	else
 	return false;
@@ -248,14 +250,21 @@ HL_API int hl_debug_wait( int pid, int *thread, int timeout ) {
 	return mdbg_session_wait(pid, thread, timeout);
 #	elif defined(USE_PTRACE)
 	int status;
-	int ret = waitpid(pid,&status,0);
-	//printf("WAITPID=%X %X\n",ret,status);
+	// *** HACK ***
+	// usleep here is needed for a good result.
+	// Without it, waitpid can miss many stop event;
+	// With it, and more we wait, less we miss stop event.
+	usleep(100 * 1000);
+	int ret = waitpid(pid, &status, WNOHANG);
 	*thread = ret;
+	if( ret == -1 && errno != EINTR )
+		return 3;
+	if( ret <= 0 )
+		return -1;
 	if( WIFEXITED(status) )
 		return 0;
 	if( WIFSTOPPED(status) ) {
 		int sig = WSTOPSIG(status);
-		//printf(" STOPSIG=%d\n",sig);
 		if( sig == SIGSTOP || sig == SIGTRAP )
 			return 1;
 		return 3;


### PR DESCRIPTION
I made some changes for the hashlink-debugger vscode extension on Linux https://github.com/vshaxe/hashlink-debugger/compare/1.4.8...1.4.9 . They are not needed for the command line version (because you can't give command when the program is still in "running" mode).
As I also made a big hack for waitpid timeout (for the moment it works on my machine without need thread+semaphore), ping @ncannasse