### PR TITLE
SSL bugfixes.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,8 +107,6 @@ jobs:
             ;;
 
           darwin*)
-            brew list --formula | xargs brew uninstall --force --ignore-dependencies
-            brew list --cask | xargs brew uninstall --force --ignore-dependencies
             brew update
             brew bundle
             ;;

--- a/libs/ssl/ssl.c
+++ b/libs/ssl/ssl.c
@@ -32,6 +32,10 @@ typedef int SOCKET;
 #include "mbedtls/x509_crt.h"
 #include "mbedtls/ssl.h"
 
+#ifdef MBEDTLS_PSA_CRYPTO_C
+#include <psa/crypto.h>
+#endif
+
 #ifdef HL_CONSOLE
 mbedtls_x509_crt *hl_init_cert_chain();
 #endif
@@ -763,6 +767,10 @@ HL_PRIM void HL_NAME(ssl_init)() {
 	mbedtls_entropy_init(&entropy);
 	mbedtls_ctr_drbg_init(&ctr_drbg);
 	mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy, NULL, 0);
+
+	#ifdef MBEDTLS_PSA_CRYPTO_C
+	psa_crypto_init();
+	#endif
 }
 
 DEFINE_PRIM(_VOID, ssl_init, _NO_ARG);

--- a/libs/ssl/ssl.c
+++ b/libs/ssl/ssl.c
@@ -36,7 +36,7 @@ typedef int SOCKET;
 mbedtls_x509_crt *hl_init_cert_chain();
 #endif
 
-#if defined(HL_WIN) || defined(HL_MAC) || defined(HL_IOS) || defined(HL_TVOS)
+#ifndef MSG_NOSIGNAL
 #	define MSG_NOSIGNAL 0
 #endif
 


### PR DESCRIPTION
- get rid of the brew uninstall hack, it doesn't seem to be needed anymore
- only define MSG_NOSIGNAL if it is actually undefined
- Use `SecTrustCopyAnchorCertificates` to get root certs on macOS instead of the deprecated keychain apis.
- Initialize PSA crypto when it is present (in mbedtls 3.6 TLS 1.3 support is turned on by default which uses PSA crypto)

The partially fixes the macOS HTTPS failures encountered in https://github.com/HaxeFoundation/haxe/pull/11638.