### PR TITLE
add missing colour formats in fmt

### DIFF
--- a/libs/fmt/fmt.c
+++ b/libs/fmt/fmt.c
@@ -56,15 +56,22 @@ HL_PRIM bool HL_NAME(png_decode)( vbyte *data, int dataLen, vbyte *out, int widt
 	case 1:
 		img.format = PNG_FORMAT_BGR;
 		break;
+	case 6:
+		img.format = PNG_FORMAT_GRAY;
+		break;
+	case 2:
 	case 7:
 		img.format = PNG_FORMAT_RGBA;
 		break;
+	case 3:
 	case 8:
 		img.format = PNG_FORMAT_BGRA;
 		break;
+	case 4:
 	case 9:
 		img.format = PNG_FORMAT_ABGR;
 		break;
+	case 5:
 	case 10:
 		img.format = PNG_FORMAT_ARGB;
 		break;


### PR DESCRIPTION
self explanatory, adds the rest of the possible colour formats from [PixelFormat](https://github.com/HaxeFoundation/haxe/blob/dc1a43dc52f98b9c480f68264885c6155e570f3e/std/hl/Format.hx#L25), the formats that replace the alpha channel with an X are the same as the alpha channel ones, since the X channel is meant to be ignored, and CMYK is impossible to do since its way too device dependant.