### PR TITLE
when doing safe_cast on HVIRTUAL, ignore extra fields from input type

### DIFF
--- a/src/std/types.c
+++ b/src/std/types.c
@@ -191,15 +191,21 @@ HL_PRIM bool hl_safe_cast( hl_type *t, hl_type *to ) {
 		return false;
 	switch( t->kind ) {
 	case HVIRTUAL:
-		if( to->virt->nfields < t->virt->nfields ) {
-			int i;
-			for(i=0;i<to->virt->nfields;i++) {
-				hl_obj_field *f1 = t->virt->fields + i;
-				hl_obj_field *f2 = to->virt->fields + i;
-				if( f1->hashed_name != f2->hashed_name || !hl_same_type(f1->t,f2->t) )
-					break;
+		if (to->virt->nfields < t->virt->nfields) {
+			int matches = 0;
+			for (int i = 0; i < to->virt->nfields; i++) {
+				hl_obj_field* f1 = to->virt->fields + i;
+
+				for (int j = i; j < t->virt->nfields; j++) {
+					hl_obj_field* f2 = t->virt->fields + j;
+
+					if (f2->hashed_name == f1->hashed_name && hl_same_type(f2->t, f1->t)) {
+						matches++;
+						break;
+					}
+				}
 			}
-			if( i == to->virt->nfields )
+			if (matches == to->virt->nfields)
 				return true;
 		}
 		break;

--- a/src/std/types.c
+++ b/src/std/types.c
@@ -191,7 +191,7 @@ HL_PRIM bool hl_safe_cast( hl_type *t, hl_type *to ) {
 		return false;
 	switch( t->kind ) {
 	case HVIRTUAL:
-		if (to->virt->nfields < t->virt->nfields) {
+		if (to->virt->nfields <= t->virt->nfields) {
 			int matches = 0;
 			for (int i = 0; i < to->virt->nfields; i++) {
 				hl_obj_field* f1 = to->virt->fields + i;


### PR DESCRIPTION
Not 100% sure this does not break anything else, but what i am attempting here is to solve the issue where interfaces that extends other interfaces and override a method signature by changing its return type ends up corrupting something making the runtime call a different unrelated method.


this fixes the interface-wrong method issue (https://github.com/HaxeFoundation/hashlink/issues/685).

Note that it does not fix the Access Violation you get from typedef example, however they seem to be related, if i on purpose set hl_vfields(v)[i]  to the method reference instead of NULL when hl_safe_cast returns false in  hl_to_virtual, the typedef variant runs just fine as well.