### PR TITLE
Fix hl_debug_break and hl_detect_debugger on Linux.

### DIFF
--- a/src/hl.h
+++ b/src/hl.h
@@ -283,7 +283,7 @@ C_FUNCTION_END
 C_FUNCTION_BEGIN
 HL_API void hl_debug_break( void );
 C_FUNCTION_END
-#elif defined(HL_LINUX) && defined(__i386__)
+#elif defined(HL_LINUX)
 #	ifdef HL_64
 #	define hl_debug_break() \
 		if( hl_detect_debugger() ) \


### PR DESCRIPTION
This enables `hl.Api.breakPoint()` and catching exceptions.