### PR TITLE
Add set window focus support to hldx/hlsdl

### DIFF
--- a/libs/directx/dx/Window.hx
+++ b/libs/directx/dx/Window.hx
@@ -145,6 +145,10 @@ class Window {
 		winResize(win, 2);
 	}
 
+	public function focus() {
+		winSetFocus(win);
+	}
+
 	public function getNextEvent( e : Event ) : Bool {
 		return winGetNextEvent(win, e);
 	}
@@ -320,6 +324,10 @@ class Window {
 	}
 
 	static function winGetPosition( win : WinPtr, x : hl.Ref<Int>, y : hl.Ref<Int> ) {
+	}
+
+	@:hlNative("?directx", "win_set_focus")
+	static function winSetFocus( win: WinPtr ) {
 	}
 
 	static function winGetOpacity( win : WinPtr ) : Float {

--- a/libs/directx/window.c
+++ b/libs/directx/window.c
@@ -699,6 +699,10 @@ HL_PRIM void HL_NAME(win_resize)(dx_window *win, int mode) {
 	}
 }
 
+HL_PRIM void HL_NAME(win_set_focus)(dx_window* win) {
+	SetFocus(win);
+}
+
 HL_PRIM void HL_NAME(win_set_fullscreen)(dx_window *win, bool fs) {
 	if( fs ) {
 		MONITORINFO mi = { sizeof(mi) };
@@ -916,6 +920,7 @@ DEFINE_PRIM(TWIN, win_create_ex, _I32 _I32 _I32 _I32 _I32);
 DEFINE_PRIM(TWIN, win_create, _I32 _I32);
 DEFINE_PRIM(_VOID, win_set_fullscreen, TWIN _BOOL);
 DEFINE_PRIM(_VOID, win_resize, TWIN _I32);
+DEFINE_PRIM(_VOID, win_set_focus, TWIN);
 DEFINE_PRIM(_VOID, win_set_title, TWIN _BYTES);
 DEFINE_PRIM(_VOID, win_set_size, TWIN _I32 _I32);
 DEFINE_PRIM(_VOID, win_set_min_size, TWIN _I32 _I32);

--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -689,6 +689,10 @@ HL_PRIM void HL_NAME(win_resize)(SDL_Window *win, int mode) {
 	}
 }
 
+HL_PRIM void HL_NAME(win_raise)(SDL_Window *win) {
+	SDL_RaiseWindow(win);
+}
+
 
 HL_PRIM void HL_NAME(win_swap_window)(SDL_Window *win) {
 #if defined(HL_IOS) || defined(HL_TVOS)
@@ -723,6 +727,7 @@ DEFINE_PRIM(_BOOL, win_set_fullscreen, TWIN _I32);
 DEFINE_PRIM(_BOOL, win_set_display_mode, TWIN _I32 _I32 _I32);
 DEFINE_PRIM(_I32, win_display_handle, TWIN);
 DEFINE_PRIM(_VOID, win_resize, TWIN _I32);
+DEFINE_PRIM(_VOID, win_raise, TWIN);
 DEFINE_PRIM(_VOID, win_set_title, TWIN _BYTES);
 DEFINE_PRIM(_VOID, win_set_position, TWIN _I32 _I32);
 DEFINE_PRIM(_VOID, win_get_position, TWIN _REF(_I32) _REF(_I32));

--- a/libs/sdl/sdl/Window.hx
+++ b/libs/sdl/sdl/Window.hx
@@ -180,6 +180,10 @@ class Window {
 		setPosition(SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 	}
 
+	public function raise() {
+		winRaise( win );
+	}
+
 	public function warpMouse( x : Int, y : Int ) {
 		warpMouseInWindow(win, x, y);
 	}
@@ -367,6 +371,10 @@ class Window {
 
 	static function winGetOpacity( win : WinPtr ) : Float {
 		return 0.0;
+	}
+
+	@:hlNative("?sdl", "win_raise")
+	static function winRaise( win : WinPtr ) {
 	}
 
 	static function winSetOpacity( win : WinPtr, opacity : Float ) : Bool {


### PR DESCRIPTION
This adds winRaise to hlSdl and winSetFocus to hldx. These are plumbed through to their respective window classes as well.

Both methods tested and working on windows 10

For winSetFocus (directx), minver is Windows 2000, not deprecated, should be safe.
for winRaise (sdl), min SDL version is 2.0.0, we should trust SDL to handle the rest.

Naming was chosen to match the underlying functions and following existing naming conventions, but I can rename either one for consistency if that is preferred.

This has a variety of minor uses in games, but the main driver is for imgui multi-window work, where we want a specific tool to grab focus for workflow reasons.