### PR TITLE
Support cmake installs with VS project templates

### DIFF
--- a/other/haxelib/templates/vs2015/__file__.vcxproj
+++ b/other/haxelib/templates/vs2015/__file__.vcxproj
@@ -72,22 +72,22 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
     <IncludePath>$$makePath(::relDir::);$(HASHLINK)/include;$(HASHLINK)/src;$(IncludePath)</IncludePath>
-    <LibraryPath>$(HASHLINK);$(HASHLINK)/$(Configuration);$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(HASHLINK);$(HASHLINK)/lib;$(HASHLINK)/$(Configuration);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
     <IncludePath>$$makePath(::relDir::);$(HASHLINK)/include;$(HASHLINK)/src;$(IncludePath)</IncludePath>
-    <LibraryPath>$(HASHLINK);$(HASHLINK)/x64/$(Configuration);$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(HASHLINK);$(HASHLINK)/lib;$(HASHLINK)/x64/$(Configuration);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>$$makePath(::relDir::);$(HASHLINK)/include;$(HASHLINK)/src;$(IncludePath)</IncludePath>
-    <LibraryPath>$(HASHLINK);$(HASHLINK)/$(Configuration)VS2015;$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(HASHLINK);$(HASHLINK)/lib;$(HASHLINK)/$(Configuration)VS2015;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>$$makePath(::relDir::);$(HASHLINK)/include;$(HASHLINK)/src;$(IncludePath)</IncludePath>
-    <LibraryPath>$(HASHLINK);$(HASHLINK)/x64/$(Configuration)VS2015;$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(HASHLINK);$(HASHLINK)/lib;$(HASHLINK)/x64/$(Configuration)VS2015;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/other/haxelib/templates/vs2017/__file__.vcxproj
+++ b/other/haxelib/templates/vs2017/__file__.vcxproj
@@ -73,22 +73,22 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
     <IncludePath>$$makePath(::relDir::);$(HASHLINK)/include;$(HASHLINK)/src;$(IncludePath)</IncludePath>
-    <LibraryPath>$(HASHLINK);$(HASHLINK)/$(Configuration);$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(HASHLINK);$(HASHLINK)/lib;$(HASHLINK)/$(Configuration);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
     <IncludePath>$$makePath(::relDir::);$(HASHLINK)/include;$(HASHLINK)/src;$(IncludePath)</IncludePath>
-    <LibraryPath>$(HASHLINK);$(HASHLINK)/x64/$(Configuration);$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(HASHLINK);$(HASHLINK)/lib;$(HASHLINK)/x64/$(Configuration);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>$$makePath(::relDir::);$(HASHLINK)/include;$(HASHLINK)/src;$(IncludePath)</IncludePath>
-    <LibraryPath>$(HASHLINK);$(HASHLINK)/$(Configuration)VS2017;$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(HASHLINK);$(HASHLINK)/lib;$(HASHLINK)/$(Configuration)VS2017;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>$$makePath(::relDir::);$(HASHLINK)/include;$(HASHLINK)/src;$(IncludePath)</IncludePath>
-    <LibraryPath>$(HASHLINK);$(HASHLINK)/x64/$(Configuration)VS2017;$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(HASHLINK);$(HASHLINK)/lib;$(HASHLINK)/x64/$(Configuration)VS2017;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/other/haxelib/templates/vs2019/__file__.vcxproj
+++ b/other/haxelib/templates/vs2019/__file__.vcxproj
@@ -73,22 +73,22 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
     <IncludePath>$$makePath(::relDir::);$(HASHLINK)/include;$(HASHLINK)/src;$(IncludePath)</IncludePath>
-    <LibraryPath>$(HASHLINK);$(HASHLINK)/$(Configuration);$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(HASHLINK);$(HASHLINK)/lib;$(HASHLINK)/$(Configuration);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>$$makePath(::relDir::);$(HASHLINK)/include;$(HASHLINK)/src;$(IncludePath)</IncludePath>
-    <LibraryPath>$(HASHLINK);$(HASHLINK)/$(Configuration);$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(HASHLINK);$(HASHLINK)/lib;$(HASHLINK)/$(Configuration);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
     <IncludePath>$$makePath(::relDir::);$(HASHLINK)/include;$(HASHLINK)/src;$(IncludePath)</IncludePath>
-    <LibraryPath>$(HASHLINK);$(HASHLINK)/x64/$(Configuration);$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(HASHLINK);$(HASHLINK)/lib;$(HASHLINK)/x64/$(Configuration);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>$$makePath(::relDir::);$(HASHLINK)/include;$(HASHLINK)/src;$(IncludePath)</IncludePath>
-    <LibraryPath>$(HASHLINK);$(HASHLINK)/x64/$(Configuration);$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(HASHLINK);$(HASHLINK)/lib;$(HASHLINK)/x64/$(Configuration);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>


### PR DESCRIPTION
When hashlink is installed via cmake, the library files end up in the `lib` subdirectory