### PR TITLE
[ci] Run hlc tests on arm64 mac

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,51 +138,10 @@ jobs:
             ;;
         esac
 
-
-    - name: "Install: Neko"
-      run: |
-        set -eux
-
-        case "${{ matrix.target }}" in
-          linux)
-            sudo apt-get install --no-install-recommends -y neko
-            ;;
-
-          darwin)
-            brew install neko
-            ;;
-
-          windows)
-            choco install --no-progress neko -y
-            nekopath=$(find C:/ProgramData/chocolatey/lib/neko -name neko.dll -printf '%h\n')
-            echo "NEKOPATH=$nekopath" >> $GITHUB_ENV
-            ;;
-        esac
-        neko || true # print neko version
-
-
-    - name: "Install: Haxe latest"
-      run: |
-        set -eux
-
-        download_url="https://build.haxe.org/builds/haxe/${{ matrix.haxe_nightly_dir }}/haxe_latest.${{ matrix.archive_ext }}"
-        echo "Downloading [$download_url]..."
-        if [[ ${{ matrix.target }} == windows ]]; then
-          curl -fsSL --retry 3 --retry-delay 5 "$download_url" -o /tmp/haxe.zip
-          7z x /tmp/haxe.zip -o/tmp
-          mv -v /tmp/haxe_* /tmp/haxe
-          cygpath -w '/tmp/haxe/' >> $GITHUB_PATH
-          echo "HAXE_STD_PATH=$(cygpath -w '/tmp/haxe/std')" >> $GITHUB_ENV
-        else
-          mkdir /tmp/haxe
-          curl -fsSL --retry 3 --retry-delay 5 "$download_url" -o /tmp/haxe.tar.gz
-          tar xzvf /tmp/haxe.tar.gz -C /tmp/haxe --strip-components=1
-          echo "/tmp/haxe/" >> $GITHUB_PATH
-          echo "HAXE_STD_PATH=/tmp/haxe/std" >> $GITHUB_ENV
-        fi
-
-        /tmp/haxe/haxe --version
-
+    - name: Install haxe
+      uses: krdlab/setup-haxe@f0a0baa8ccdb1fe4fc316c8f30eb3ca77aa4ea4e
+      with:
+        haxe-version: latest
 
     - name: "Configure: Haxelib"
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [linux, darwin, windows]
-        architecture: [32, 64]
+        architecture: [32, 64, arm64]
         build_system: [make, cmake, vs2019]
 
         include:
@@ -32,9 +32,16 @@ jobs:
             archive_ext: tar.gz
 
           - target: darwin
-            runner: macos-12
             haxe_nightly_dir: mac
             archive_ext: tar.gz
+
+          - target: darwin
+            architecture: 64
+            runner: macos-12
+
+          - target: darwin
+            architecture: arm64
+            runner: macos-14
 
           - build_system: cmake
             cmake_configuration: RelWithDebInfo
@@ -73,6 +80,12 @@ jobs:
 
           - target: darwin
             architecture: 32
+
+          - target: linux
+            architecture: arm64
+
+          - target: windows
+            architecture: arm64
 
           - target: windows
             build_system: make
@@ -237,24 +250,26 @@ jobs:
             ${{ env.WINDOWS_BUILD_FOLDER }}/hl.exe --version
             ;;
           make)
-            ./hl --version
-            case ${{ matrix.target }} in
-              linux)  ldd -v ./hl ;;
-              darwin) otool -L ./hl ;;
-            esac
+            if [[ ${{ matrix.architecture }} != arm64 ]]; then
+              ./hl --version
+              case ${{ matrix.target }} in
+                linux)  ldd -v ./hl ;;
+                darwin) otool -L ./hl ;;
+              esac
 
-            haxe -hl hello.hl -cp other/tests -main HelloWorld -D interp
-            ./hl hello.hl
+              haxe -hl hello.hl -cp other/tests -main HelloWorld -D interp
+              ./hl hello.hl
+
+              # ensure the executable still works when installed globally
+              cp hello.hl /tmp
+              pushd /tmp
+              hl hello.hl
+              popd
+            fi
 
             haxe -hl src/_main.c -cp other/tests -main HelloWorld
             make hlc
             ./hlc
-
-            # ensure the executable still works when installed globally
-            cp hello.hl /tmp
-            pushd /tmp
-            hl hello.hl
-            popd
             ;;
         esac
 
@@ -264,7 +279,8 @@ jobs:
         set -eux
 
         case "${{ matrix.target }}${{matrix.architecture}}" in
-          darwin*)   platform_name=darwin ;;
+          darwinarm64)   platform_name=darwin-arm64 ;;
+          darwin64)   platform_name=darwin ;;
           windows*)  platform_name=win${{matrix.architecture}} ;;
           linux64)   platform_name=linux-amd64 ;;
         esac
@@ -332,6 +348,7 @@ jobs:
           --prerelease \
           --title "HashLink Nightly Build" \
           "darwin-make-64/hashlink-${short_commit}-darwin.tar.gz#hashlink-latest-darwin.tar.gz" \
+          "darwin-make-arm64/hashlink-${short_commit}-darwin-arm64.tar.gz#hashlink-latest-darwin-arm64.tar.gz" \
           "linux-make-64/hashlink-${short_commit}-linux-amd64.tar.gz#hashlink-latest-linux-amd64.tar.gz" \
           "windows-vs2019-32/hashlink-${short_commit}-win32.zip#hashlink-latest-win32.zip" \
           "windows-vs2019-64/hashlink-${short_commit}-win64.zip#hashlink-latest-win64.zip"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,13 @@ include(GNUInstallDirs)
 include(FindPkgConfig)
 include(CTest)
 
+set(WITH_VM_DEFAULT ON)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
+    set(WITH_VM_DEFAULT OFF)
+endif()
+
+option(WITH_VM "Whether to build the Hashlink virtual machine" ${WITH_VM_DEFAULT})
+
 # force Unicode over Multi-byte
 if(MSVC)
     add_definitions(-DUNICODE -D_UNICODE)
@@ -165,24 +172,29 @@ set_target_properties(libhl
     COMPILE_DEFINITIONS "_USRDLL;LIBHL_EXPORTS;HAVE_CONFIG_H;PCRE2_CODE_UNIT_WIDTH=16"
 )
 
-add_executable(hl
-    src/code.c
-    src/jit.c
-    src/main.c
-    src/module.c
-    src/debugger.c
-    src/profile.c
-)
+if (WITH_VM)
+    add_executable(hl
+        src/code.c
+        src/jit.c
+        src/main.c
+        src/module.c
+        src/debugger.c
+        src/profile.c
+    )
 
-if (UNIX AND NOT APPLE)
-    set_target_properties(hl PROPERTIES INSTALL_RPATH "$ORIGIN;${CMAKE_INSTALL_PREFIX}/lib")
+    if (UNIX AND NOT APPLE)
+        set_target_properties(hl PROPERTIES INSTALL_RPATH "$ORIGIN;${CMAKE_INSTALL_PREFIX}/lib")
+    endif()
+
+    target_link_libraries(hl libhl)
+
+    if (WIN32)
+        target_link_libraries(hl user32)
+    endif()
 endif()
-
-target_link_libraries(hl libhl)
 
 if(WIN32)
     target_link_libraries(libhl ws2_32 user32)
-    target_link_libraries(hl user32)
 else()
     target_link_libraries(libhl m dl pthread)
 endif()
@@ -299,16 +311,26 @@ if(BUILD_TESTING)
 
     #####################
     # Tests
+    if (WITH_VM)
+        add_test(NAME version
+            COMMAND hl --version
+        )
+        set_tests_properties(version
+            PROPERTIES
+            PASS_REGULAR_EXPRESSION "${HL_VERSION}"
+        )
 
-    add_test(NAME hello.hl
-        COMMAND hl ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test/hello.hl
-    )
-    add_test(NAME threads.hl
-        COMMAND hl ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test/threads.hl
-    )
-    add_test(NAME uvsample.hl
-        COMMAND hl ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test/uvsample.hl 6001
-    )
+        add_test(NAME hello.hl
+            COMMAND hl ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test/hello.hl
+        )
+        add_test(NAME threads.hl
+            COMMAND hl ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test/threads.hl
+        )
+        add_test(NAME uvsample.hl
+            COMMAND hl ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test/uvsample.hl 6001
+        )
+    endif()
+
     add_test(NAME hello
         COMMAND hello
     )
@@ -318,14 +340,6 @@ if(BUILD_TESTING)
     add_test(NAME uvsample
         COMMAND uvsample 6002
     )
-    add_test(NAME version
-        COMMAND hl --version
-    )
-    set_tests_properties(version
-        PROPERTIES
-        PASS_REGULAR_EXPRESSION "${HL_VERSION}"
-    )
-
 endif()
 
 #####################
@@ -351,10 +365,14 @@ set(HDLL_DESTINATION
     ${CMAKE_INSTALL_LIBDIR}
 )
 
+set(INSTALL_TARGETS libhl)
+if (WITH_VM)
+    list(APPEND INSTALL_TARGETS hl)
+endif()
+
 install(
     TARGETS
-        hl
-        libhl
+        ${INSTALL_TARGETS}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,11 @@ release_win:
 	rm -rf $(PACKAGE_NAME)
 
 release_linux release_osx:
+ifeq ($(ARCH),arm64)
+	cp libhl.$(LIBEXT) *.hdll $(PACKAGE_NAME)
+else
 	cp hl libhl.$(LIBEXT) *.hdll $(PACKAGE_NAME)
+endif
 	tar -cvzf $(PACKAGE_NAME).tar.gz $(PACKAGE_NAME)
 	rm -rf $(PACKAGE_NAME)
 

--- a/Makefile
+++ b/Makefile
@@ -169,12 +169,19 @@ ifdef DEBUG
 CFLAGS += -g
 endif
 
-all: libhl hl libs
+all: libhl libs
+ifeq ($(ARCH),arm64)
+	$(warning HashLink vm is not supported on arm64, skipping)
+else
+all: hl
+endif
 
 install:
 	$(UNAME)==Darwin && ${MAKE} uninstall
+ifneq ($(ARCH),arm64)
 	mkdir -p $(INSTALL_BIN_DIR)
 	cp hl $(INSTALL_BIN_DIR)
+endif
 	mkdir -p $(INSTALL_LIB_DIR)
 	cp *.hdll $(INSTALL_LIB_DIR)
 	cp libhl.${LIBEXT} $(INSTALL_LIB_DIR)

--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ release_haxelib_package:
 	rm -rf $(HLIB)_release
 
 BUILD_DIR ?= .
-PACKAGE_NAME := hashlink-$(shell $(BUILD_DIR)/hl --version)-$(RELEASE_NAME)
+PACKAGE_NAME = $(eval PACKAGE_NAME := hashlink-$(shell $(BUILD_DIR)/hl --version)-$(RELEASE_NAME))$(PACKAGE_NAME)
 
 release_prepare:
 	rm -rf $(PACKAGE_NAME)


### PR DESCRIPTION
This ensures that the build works and passes the hlc tests on arm64 mac. It also releases binaries for the libraries, but not the `hl` binary since that is not supported on arm64.

Closes #521.