### PR TITLE
Fix compile issue for iOS

### DIFF
--- a/src/std/thread.c
+++ b/src/std/thread.c
@@ -970,7 +970,7 @@ HL_PRIM void hl_thread_set_name( hl_thread *t, const char *name ) {
 	// nothing
 #elif defined(HL_WIN)
 	SetThreadName((DWORD)(int_val)t,name);
-#elif defined(HL_MAC)
+#elif defined(HL_MAC) || defined(HL_IOS)
 	// pthread_setname_np only possible for current thread
 #else
 	pthread_setname_np((pthread_t)t,name);


### PR DESCRIPTION
"hl_thread_set_name" also isn't available on iOS. I would assume tvOS too, but could not test myself