### PR TITLE
[hlc] Use precompiled headers in vs templates

### DIFF
--- a/other/haxelib/templates/vs2015/__file__.vcxproj
+++ b/other/haxelib/templates/vs2015/__file__.vcxproj
@@ -99,6 +99,8 @@
       <SDLCheck>true</SDLCheck>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -116,6 +118,8 @@
       <SDLCheck>true</SDLCheck>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -135,6 +139,8 @@
       <SDLCheck>true</SDLCheck>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -156,6 +162,8 @@
       <SDLCheck>true</SDLCheck>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -165,7 +173,10 @@
       <AdditionalDependencies>libhl.lib::foreach libraries::;::name::.lib::end::</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemGroup>::foreach cfiles::
+  <ItemGroup>
+    <ClCompile Include="stdafx.c">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>::foreach cfiles::
     <ClCompile Include="::relDir::::path::" />::end::
   </ItemGroup>
   <ItemGroup>::foreach hfiles::

--- a/other/haxelib/templates/vs2015/__file__.vcxproj
+++ b/other/haxelib/templates/vs2015/__file__.vcxproj
@@ -101,6 +101,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4703;4100;4101;4102;4204;4221;4244;4700;4701;4702;4703;4715;4716;4723</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -120,6 +121,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4703;4100;4101;4102;4204;4221;4244;4700;4701;4702;4703;4715;4716;4723</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -141,6 +143,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4703;4100;4101;4102;4204;4221;4244;4700;4701;4702;4703;4715;4716;4723</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -164,6 +167,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4703;4100;4101;4102;4204;4221;4244;4700;4701;4702;4703;4715;4716;4723</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/other/haxelib/templates/vs2015/__file__.vcxproj.filters
+++ b/other/haxelib/templates/vs2015/__file__.vcxproj.filters
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>::foreach cfiles::::if directory::
+  <ItemGroup>
+    <ClCompile Include="stdafx.c" />::foreach cfiles::::if directory::
     <ClCompile Include="::relDir::::path::">
       <Filter>$$winPath(::directory::)</Filter>
     </ClCompile>::else::

--- a/other/haxelib/templates/vs2015/stdafx.c
+++ b/other/haxelib/templates/vs2015/stdafx.c
@@ -1,0 +1,1 @@
+#include "stdafx.h"

--- a/other/haxelib/templates/vs2015/stdafx.h
+++ b/other/haxelib/templates/vs2015/stdafx.h
@@ -1,5 +1,2 @@
 #define HLC_BOOT
 #include <hlc.h>
-
-::foreach hfiles::
-#include <::relDir::::path::>::end::

--- a/other/haxelib/templates/vs2015/stdafx.h
+++ b/other/haxelib/templates/vs2015/stdafx.h
@@ -1,0 +1,5 @@
+#define HLC_BOOT
+#include <hlc.h>
+
+::foreach hfiles::
+#include <::relDir::::path::>::end::

--- a/other/haxelib/templates/vs2017/__file__.vcxproj
+++ b/other/haxelib/templates/vs2017/__file__.vcxproj
@@ -101,6 +101,8 @@
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -119,6 +121,8 @@
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -139,6 +143,8 @@
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -161,6 +167,8 @@
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -170,7 +178,10 @@
       <AdditionalDependencies>libhl.lib::foreach libraries::;::name::.lib::end::</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemGroup>::foreach cfiles::
+  <ItemGroup>
+    <ClCompile Include="stdafx.c">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>::foreach cfiles::
     <ClCompile Include="::relDir::::path::" />::end::
   </ItemGroup>
   <ItemGroup>::foreach hfiles::

--- a/other/haxelib/templates/vs2017/__file__.vcxproj
+++ b/other/haxelib/templates/vs2017/__file__.vcxproj
@@ -103,6 +103,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4703;4100;4101;4102;4204;4221;4244;4700;4701;4702;4703;4715;4716;4723</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -123,6 +124,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4703;4100;4101;4102;4204;4221;4244;4700;4701;4702;4703;4715;4716;4723</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -145,6 +147,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4703;4100;4101;4102;4204;4221;4244;4700;4701;4702;4703;4715;4716;4723</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -169,6 +172,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4703;4100;4101;4102;4204;4221;4244;4700;4701;4702;4703;4715;4716;4723</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/other/haxelib/templates/vs2017/__file__.vcxproj.filters
+++ b/other/haxelib/templates/vs2017/__file__.vcxproj.filters
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>::foreach cfiles::::if directory::
+  <ItemGroup>
+    <ClCompile Include="stdafx.c" />::foreach cfiles::::if directory::
     <ClCompile Include="::relDir::::path::">
       <Filter>$$winPath(::directory::)</Filter>
     </ClCompile>::else::

--- a/other/haxelib/templates/vs2017/stdafx.c
+++ b/other/haxelib/templates/vs2017/stdafx.c
@@ -1,0 +1,1 @@
+#include "stdafx.h"

--- a/other/haxelib/templates/vs2017/stdafx.h
+++ b/other/haxelib/templates/vs2017/stdafx.h
@@ -1,5 +1,2 @@
 #define HLC_BOOT
 #include <hlc.h>
-
-::foreach hfiles::
-#include <::relDir::::path::>::end::

--- a/other/haxelib/templates/vs2017/stdafx.h
+++ b/other/haxelib/templates/vs2017/stdafx.h
@@ -1,0 +1,5 @@
+#define HLC_BOOT
+#include <hlc.h>
+
+::foreach hfiles::
+#include <::relDir::::path::>::end::

--- a/other/haxelib/templates/vs2019/__file__.vcxproj
+++ b/other/haxelib/templates/vs2019/__file__.vcxproj
@@ -101,6 +101,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4703;4100;4101;4102;4204;4221;4244;4700;4701;4702;4703;4715;4716;4723</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -121,6 +122,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4703;4100;4101;4102;4204;4221;4244;4700;4701;4702;4703;4715;4716;4723</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -141,6 +143,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4703;4100;4101;4102;4204;4221;4244;4700;4701;4702;4703;4715;4716;4723</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -161,6 +164,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4703;4100;4101;4102;4204;4221;4244;4700;4701;4702;4703;4715;4716;4723</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/other/haxelib/templates/vs2019/__file__.vcxproj
+++ b/other/haxelib/templates/vs2019/__file__.vcxproj
@@ -99,6 +99,8 @@
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -117,6 +119,8 @@
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -135,6 +139,8 @@
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -153,6 +159,8 @@
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -162,7 +170,10 @@
       <AdditionalDependencies>libhl.lib::foreach libraries::;::name::.lib::end::</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemGroup>::foreach cfiles::
+  <ItemGroup>
+    <ClCompile Include="stdafx.c">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>::foreach cfiles::
     <ClCompile Include="::relDir::::path::" />::end::
   </ItemGroup>
   <ItemGroup>::foreach hfiles::

--- a/other/haxelib/templates/vs2019/__file__.vcxproj.filters
+++ b/other/haxelib/templates/vs2019/__file__.vcxproj.filters
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>::foreach cfiles::::if directory::
+  <ItemGroup>
+    <ClCompile Include="stdafx.c" />::foreach cfiles::::if directory::
     <ClCompile Include="::relDir::::path::">
       <Filter>$$winPath(::directory::)</Filter>
     </ClCompile>::else::

--- a/other/haxelib/templates/vs2019/stdafx.c
+++ b/other/haxelib/templates/vs2019/stdafx.c
@@ -1,0 +1,1 @@
+#include "stdafx.h"

--- a/other/haxelib/templates/vs2019/stdafx.h
+++ b/other/haxelib/templates/vs2019/stdafx.h
@@ -1,5 +1,2 @@
 #define HLC_BOOT
 #include <hlc.h>
-
-::foreach hfiles::
-#include <::relDir::::path::>::end::

--- a/other/haxelib/templates/vs2019/stdafx.h
+++ b/other/haxelib/templates/vs2019/stdafx.h
@@ -1,0 +1,5 @@
+#define HLC_BOOT
+#include <hlc.h>
+
+::foreach hfiles::
+#include <::relDir::::path::>::end::


### PR DESCRIPTION
Instead of having to recompile the headers for each individual source file, the headers are now compiled once for the whole project. This gives a further speed up from ~7 seconds to ~3 seconds.