### PR TITLE
Bump x86_64 macOS runner to macOS 13.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
 
           - target: darwin
             architecture: 64
-            runner: macos-12
+            runner: macos-13
 
           - target: darwin
             architecture: arm64


### PR DESCRIPTION
The macOS 12 runner image is deprecated and will be removed soon: https://github.com/actions/runner-images/issues/10721