### PR TITLE
Hot Reload: fix new global not initialized

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -896,12 +896,16 @@ h_bool hl_module_patch( hl_module *m1, hl_code *c ) {
 	hl_module_add(m2);
 
 	// call entry point (will only update types)
-	if( m2->functions_ptrs[c->entrypoint] ) {
-		vclosure cl;
-		cl.t = c->functions[m2->functions_indexes[c->entrypoint]].type;
-		cl.fun = m2->functions_ptrs[c->entrypoint];
-		cl.hasValue = 0;
-		hl_dyn_call(&cl,NULL,0);
+	for(i=modules_count-1;i>=0;i--) {
+		hl_module *m = cur_modules[i];
+		if( m->functions_ptrs[m->code->entrypoint] ) {
+			vclosure cl;
+			cl.t = m->code->functions[m->functions_indexes[m->code->entrypoint]].type;
+			cl.fun = m->functions_ptrs[m->code->entrypoint];
+			cl.hasValue = 0;
+			hl_dyn_call(&cl,NULL,0);
+			break;
+		}
 	}
 
 	return true;


### PR DESCRIPTION
In the following code based on https://github.com/HaxeFoundation/hashlink/issues/145 , uncomment `trace` after launch will
- successfully print once after the first reload (4 changes detected: modified `foo`, `entrypoint`, new `haxe.Log.formatOutput`, `haxe.Log.trace`),
  - note that if we do not run any `hl.Api.checkReload` after the first reload, the program runs correctly.
- then read access violation after the second reload (2 changes detected, even no change on hl bytecode: new `haxe.Log.formatOutput`, `haxe.Log.trace`) at the beginning of `foo()`, probably `global 2, 9 field 1,2[6]` with `global 9: haxe.$Log`.


```haxe
class Main {
	static var g1 = 0;
	static function foo() {
		// haxe.Log.trace("additional print"); // <- after launch, uncomment this line and save
		return 10000 + g1++;
	}

	static function reload() {
		Sys.sleep(1); // make sure timestamp is different
		Sys.command("haxe",["-hl","main.hl","-main","Main"]);
		Sys.println(hl.Api.checkReload() ? "Module Reloaded" : "Module not reloaded");
	}

	static function main() {
		while( true ) {
			var val = foo();
			Sys.println(val);
			reload();
		}
	}
}
```

When debugging, I saw that additional global values are forced reset in `hl_module_patch` every time `memset(m2->globals_data+m1->globals_size,0,gsize - m1->globals_size)` and are initialized by `hl_module_init_constant(m2, c)` and `m2->functions_ptrs[c->entrypoint]`.
However, on the second reload, entrypoint function was not modified and is not called, leaving some global values to 0 (likely `haxe.$Log`, `hl.CoreType`, `hl.CoreEnum`).

This PR try to fix it by re-call the last entrypoint function.
(I think it does not work if no change is detected, for example if new functions are memorized by m1 in the future; but for now if a new type is added, there are likely some new functions)