### PR TITLE
Fix filtering another memory dump from memory tool

### DIFF
--- a/other/haxelib/hlmem/Memory.hx
+++ b/other/haxelib/hlmem/Memory.hx
@@ -940,12 +940,14 @@ class Memory {
 			return false;
 		case Intersect:
 			for( m in otherMems ) {
-				if( m.pointerBlock.get(b.addr ) == null )
+				var b2 = m.pointerBlock.get(b.addr);
+				if( b2 == null || b2.typePtr != b.typePtr || b2.size != b.size)
 					return true;
 			}
 		case Unique:
 			for( m in otherMems ) {
-				if( m.pointerBlock.get(b.addr ) != null )
+				var b2 = m.pointerBlock.get(b.addr);
+				if( b2 != null && b2.typePtr == b.typePtr && b2.size == b.size )
 					return true;
 			}
 		}


### PR DESCRIPTION
Blocks with the same address but varying types and size will not be considered the same block anymore