### PR TITLE
[hlc] Add jumbo build for vs template

### DIFF
--- a/other/haxelib/Run.hx
+++ b/other/haxelib/Run.hx
@@ -46,7 +46,7 @@ class Build {
 			tpl = "vs2015";
 		var srcDir = tpl;
 		var targetDir = config.defines.get("hlgen.makefilepath");
-		var jumboBuild = config.defines.get("hlgen.nojumbo") == null;
+		var jumboBuild = config.defines.get("hlgen.makefile.jumbo");
 		var relDir = "";
 		if( targetDir == null )
 			targetDir = this.targetDir;
@@ -126,7 +126,7 @@ class Build {
 				}
 				var content = sys.io.File.getContent(srcPath);
 				var tpl = new haxe.Template(content);
-				content = tpl.execute({
+				var context = {
 					name : this.name,
 					libraries : [for( l in config.libs ) if( l != "std" ) { name : l }],
 					files : files,
@@ -135,7 +135,8 @@ class Build {
 					cfiles : [for( f in files ) if( StringTools.endsWith(f.path,".c") ) f],
 					hfiles : [for( f in files ) if( StringTools.endsWith(f.path,".h") ) f],
 					jumboBuild : jumboBuild,
-				},{
+				};
+				var macros = {
 					makeUID : function(_,s:String) {
 						var sha1 = haxe.crypto.Sha1.encode(s);
 						sha1 = sha1.toUpperCase();
@@ -149,7 +150,12 @@ class Build {
 					},
 					winPath : function(_,s:String) return s.split("/").join("\\"),
 					getEnv : function(_,s:String) return Sys.getEnv(s),
-				});
+					setDefaultJumboBuild: function(_, b:String) {
+						context.jumboBuild ??= b;
+						return "";
+					}
+				};
+				content = tpl.execute(context, macros);
 				var prevContent = try sys.io.File.getContent(targetPath) catch( e : Dynamic ) null;
 				if( prevContent != content )
 					sys.io.File.saveContent(targetPath, content);

--- a/other/haxelib/Run.hx
+++ b/other/haxelib/Run.hx
@@ -46,6 +46,7 @@ class Build {
 			tpl = "vs2015";
 		var srcDir = tpl;
 		var targetDir = config.defines.get("hlgen.makefilepath");
+		var jumboBuild = config.defines.get("hlgen.nojumbo") == null;
 		var relDir = "";
 		if( targetDir == null )
 			targetDir = this.targetDir;
@@ -133,6 +134,7 @@ class Build {
 					directories : directories,
 					cfiles : [for( f in files ) if( StringTools.endsWith(f.path,".c") ) f],
 					hfiles : [for( f in files ) if( StringTools.endsWith(f.path,".h") ) f],
+					jumboBuild : jumboBuild,
 				},{
 					makeUID : function(_,s:String) {
 						var sha1 = haxe.crypto.Sha1.encode(s);

--- a/other/haxelib/templates/vs2015/__file__.vcxproj
+++ b/other/haxelib/templates/vs2015/__file__.vcxproj
@@ -1,4 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿$$setDefaultJumboBuild(true)
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -95,7 +96,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;::if (jumboBuild != "true")::HL_MAKE;::end::%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -115,7 +116,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;::if (jumboBuild != "true")::HL_MAKE;::end::%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -137,7 +138,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;::if (jumboBuild != "true")::HL_MAKE;::end::%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -161,7 +162,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;::if (jumboBuild != "true")::HL_MAKE;::end::%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -180,17 +181,17 @@
   <ItemGroup>
     <ClCompile Include="stdafx.c">
       <PrecompiledHeader>Create</PrecompiledHeader>
-    </ClCompile>
-    ::if jumboBuild::<ClCompile Include="::relDir::::name::.c" />
+    </ClCompile>::if (jumboBuild == "true")::
+    <ClCompile Include="::relDir::::name::.c" />
     <!--::end::::foreach cfiles::
-    <ClCompile Include="::relDir::::path::" />::end::
-    ::if jumboBuild::-->::end::
-  </ItemGroup>
-  ::if jumboBuild::<!--::end::
+    <ClCompile Include="::relDir::::path::" />::end::::if (jumboBuild == "true")::
+    -->::end::
+  </ItemGroup>::if (jumboBuild == "true")::
+  <!--::end::
   <ItemGroup>::foreach hfiles::
     <ClInclude Include="::relDir::::path::" />::end::
-  </ItemGroup>
-  ::if jumboBuild::-->::end::
+  </ItemGroup>::if (jumboBuild == "true")::
+  -->::end::
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/other/haxelib/templates/vs2015/__file__.vcxproj
+++ b/other/haxelib/templates/vs2015/__file__.vcxproj
@@ -95,7 +95,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;HL_MAKE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -115,7 +115,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;HL_MAKE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -137,7 +137,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;HL_MAKE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -161,7 +161,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;HL_MAKE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -180,12 +180,17 @@
   <ItemGroup>
     <ClCompile Include="stdafx.c">
       <PrecompiledHeader>Create</PrecompiledHeader>
-    </ClCompile>::foreach cfiles::
+    </ClCompile>
+    ::if jumboBuild::<ClCompile Include="::relDir::::name::.c" />
+    <!--::end::::foreach cfiles::
     <ClCompile Include="::relDir::::path::" />::end::
+    ::if jumboBuild::-->::end::
   </ItemGroup>
+  ::if jumboBuild::<!--::end::
   <ItemGroup>::foreach hfiles::
     <ClInclude Include="::relDir::::path::" />::end::
   </ItemGroup>
+  ::if jumboBuild::-->::end::
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/other/haxelib/templates/vs2015/__file__.vcxproj
+++ b/other/haxelib/templates/vs2015/__file__.vcxproj
@@ -1,5 +1,4 @@
-﻿$$setDefaultJumboBuild(true)
-<?xml version="1.0" encoding="utf-8"?>
+﻿$$setDefaultJumboBuild(true)<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">

--- a/other/haxelib/templates/vs2017/__file__.vcxproj
+++ b/other/haxelib/templates/vs2017/__file__.vcxproj
@@ -1,5 +1,4 @@
-﻿$$setDefaultJumboBuild(true)
-<?xml version="1.0" encoding="utf-8"?>
+﻿$$setDefaultJumboBuild(true)<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">

--- a/other/haxelib/templates/vs2017/__file__.vcxproj
+++ b/other/haxelib/templates/vs2017/__file__.vcxproj
@@ -97,7 +97,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;HL_MAKE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -118,7 +118,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;HL_MAKE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -141,7 +141,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;HL_MAKE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -166,7 +166,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;HL_MAKE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -185,12 +185,17 @@
   <ItemGroup>
     <ClCompile Include="stdafx.c">
       <PrecompiledHeader>Create</PrecompiledHeader>
-    </ClCompile>::foreach cfiles::
+    </ClCompile>
+    ::if jumboBuild::<ClCompile Include="::relDir::::name::.c" />
+    <!--::end::::foreach cfiles::
     <ClCompile Include="::relDir::::path::" />::end::
+    ::if jumboBuild::-->::end::
   </ItemGroup>
+  ::if jumboBuild::<!--::end::
   <ItemGroup>::foreach hfiles::
     <ClInclude Include="::relDir::::path::" />::end::
   </ItemGroup>
+  ::if jumboBuild::-->::end::
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/other/haxelib/templates/vs2017/__file__.vcxproj
+++ b/other/haxelib/templates/vs2017/__file__.vcxproj
@@ -1,4 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿$$setDefaultJumboBuild(true)
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -97,7 +98,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;::if (jumboBuild != "true")::HL_MAKE;::end::%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -118,7 +119,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;::if (jumboBuild != "true")::HL_MAKE;::end::%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -141,7 +142,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;::if (jumboBuild != "true")::HL_MAKE;::end::%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -166,7 +167,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;::if (jumboBuild != "true")::HL_MAKE;::end::%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -185,17 +186,17 @@
   <ItemGroup>
     <ClCompile Include="stdafx.c">
       <PrecompiledHeader>Create</PrecompiledHeader>
-    </ClCompile>
-    ::if jumboBuild::<ClCompile Include="::relDir::::name::.c" />
+    </ClCompile>::if (jumboBuild == "true")::
+    <ClCompile Include="::relDir::::name::.c" />
     <!--::end::::foreach cfiles::
-    <ClCompile Include="::relDir::::path::" />::end::
-    ::if jumboBuild::-->::end::
-  </ItemGroup>
-  ::if jumboBuild::<!--::end::
+    <ClCompile Include="::relDir::::path::" />::end::::if (jumboBuild == "true")::
+    -->::end::
+  </ItemGroup>::if (jumboBuild == "true")::
+  <!--::end::
   <ItemGroup>::foreach hfiles::
     <ClInclude Include="::relDir::::path::" />::end::
-  </ItemGroup>
-  ::if jumboBuild::-->::end::
+  </ItemGroup>::if (jumboBuild == "true")::
+  -->::end::
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/other/haxelib/templates/vs2019/__file__.vcxproj
+++ b/other/haxelib/templates/vs2019/__file__.vcxproj
@@ -1,5 +1,4 @@
-﻿$$setDefaultJumboBuild(true)
-<?xml version="1.0" encoding="utf-8"?>
+﻿$$setDefaultJumboBuild(true)<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">

--- a/other/haxelib/templates/vs2019/__file__.vcxproj
+++ b/other/haxelib/templates/vs2019/__file__.vcxproj
@@ -95,7 +95,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;HL_MAKE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -116,7 +116,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;HL_MAKE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -137,7 +137,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;HL_MAKE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -158,7 +158,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;HL_MAKE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -177,12 +177,17 @@
   <ItemGroup>
     <ClCompile Include="stdafx.c">
       <PrecompiledHeader>Create</PrecompiledHeader>
-    </ClCompile>::foreach cfiles::
+    </ClCompile>
+    ::if jumboBuild::<ClCompile Include="::relDir::::name::.c" />
+    <!--::end::::foreach cfiles::
     <ClCompile Include="::relDir::::path::" />::end::
+    ::if jumboBuild::-->::end::
   </ItemGroup>
+  ::if jumboBuild::<!--::end::
   <ItemGroup>::foreach hfiles::
     <ClInclude Include="::relDir::::path::" />::end::
   </ItemGroup>
+  ::if jumboBuild::-->::end::
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/other/haxelib/templates/vs2019/__file__.vcxproj
+++ b/other/haxelib/templates/vs2019/__file__.vcxproj
@@ -1,4 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿$$setDefaultJumboBuild(true)
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -95,7 +96,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;::if (jumboBuild != "true")::HL_MAKE;::end::%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -116,7 +117,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;::if (jumboBuild != "true")::HL_MAKE;::end::%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -137,7 +138,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;::if (jumboBuild != "true")::HL_MAKE;::end::%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -158,7 +159,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;::if !jumboBuild::HL_MAKE;::end::;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;::if (jumboBuild != "true")::HL_MAKE;::end::%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <ObjectFileName>$(IntDir)\%(RelativeDir)</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -177,17 +178,17 @@
   <ItemGroup>
     <ClCompile Include="stdafx.c">
       <PrecompiledHeader>Create</PrecompiledHeader>
-    </ClCompile>
-    ::if jumboBuild::<ClCompile Include="::relDir::::name::.c" />
+    </ClCompile>::if (jumboBuild == "true")::
+    <ClCompile Include="::relDir::::name::.c" />
     <!--::end::::foreach cfiles::
-    <ClCompile Include="::relDir::::path::" />::end::
-    ::if jumboBuild::-->::end::
-  </ItemGroup>
-  ::if jumboBuild::<!--::end::
+    <ClCompile Include="::relDir::::path::" />::end::::if (jumboBuild == "true")::
+    -->::end::
+  </ItemGroup>::if (jumboBuild == "true")::
+  <!--::end::
   <ItemGroup>::foreach hfiles::
     <ClInclude Include="::relDir::::path::" />::end::
-  </ItemGroup>
-  ::if jumboBuild::-->::end::
+  </ItemGroup>::if (jumboBuild == "true")::
+  -->::end::
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>


### PR DESCRIPTION
Add jumbo build (aka unity build but I prefer avoid using "unity") for hlc templates and use it by default for better hlc compilation speed with Visual Studio (especially when use hl/jit for dev and hl/c for release).
If incremental build is preferred, jumbo build can be disabled by setting `-D hlgen.nojumbo`.

@tobil4sk made a couple of tests and it turns out that this all-in-one build strategy is still the quickest and is a known approach. It's already used internally in Shiro's project but was made by manually editing vcsproj file.