### PR TITLE
[ci] upgrade to Ubuntu 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
         include:
           - target: linux
-            runner: ubuntu-20.04
+            runner: ubuntu-22.04
             haxe_nightly_dir: linux64
             archive_ext: tar.gz
 


### PR DESCRIPTION
The Ubuntu 20.04 runner will begin deprecation in February and be fully unsupported by April: https://github.com/actions/runner-images/issues/11101