### PR TITLE
[std] Prevent process stdin being closed twice

### DIFF
--- a/src/std/process.c
+++ b/src/std/process.c
@@ -61,7 +61,9 @@ static void process_finalize( vprocess *p ) {
 #	ifdef HL_WIN
 	CloseHandle(p->eread);
 	CloseHandle(p->oread);
-	CloseHandle(p->iwrite);
+	if (p->iwrite != NULL) {
+		CloseHandle(p->iwrite);
+	}
 	CloseHandle(p->pinf.hProcess);
 	CloseHandle(p->pinf.hThread);
 #	else
@@ -235,6 +237,7 @@ HL_PRIM bool hl_process_stdin_close( vprocess *p ) {
 #	ifdef HL_WIN
 	if( !CloseHandle(p->iwrite) )
 		return false;
+	p->iwrite = NULL;
 #	else
 	if( close(p->iwrite) )
 		return false;


### PR DESCRIPTION
When running `process_stdin_close`, the handle is made available again and may be reused in another part of the program. This means that it is not safe to rerun `CloseHandle` in `process_finalize`, since that could cause us to close a handle that no longer belongs to the process.

See: https://github.com/HaxeFoundation/neko/pull/300