### PR TITLE
Fix cast from void to dynamic cause segfault

### DIFF
--- a/src/std/cast.c
+++ b/src/std/cast.c
@@ -74,6 +74,8 @@ HL_PRIM vdynamic *hl_make_dyn( void *data, hl_type *t ) {
 			v->v.ptr = p;
 			return v;
 		}
+	case HVOID:
+		return NULL;
 	default:
 		return *(vdynamic**)data;
 	}


### PR DESCRIPTION
Should fix @jacobalbano 's error on JIT, see https://github.com/HaxeFoundation/hashlink/issues/735#issuecomment-2677052049

Callstack:
```
libhl.dll!hl_make_dyn(void * data, hl_type * t) Line 78
libhl.dll!hl_dyn_castp(void * data, hl_type * t, hl_type * to) Line 222
libhl.dll!hl_wrapper_call(void * _c, void * * args, vdynamic * ret) Line 327
libhl.dll!hl_dyn_call_obj(vdynamic * o, hl_type * ft, int hfield, void * * args, vdynamic * ret) Line 352
```