### PR TITLE
Fix makeVarArgs cast to func and call as dyn segfault

### DIFF
--- a/src/std/fun.c
+++ b/src/std/fun.c
@@ -149,6 +149,9 @@ HL_PRIM vdynamic* hl_call_method( vdynamic *c, varray *args ) {
 	if( args->size > HL_MAX_ARGS )
 		hl_error("Too many arguments");
 	if( cl->hasValue ) {
+		while( cl->hasValue == 2 ) {
+			cl = ((vclosure_wrapper*)cl)->wrappedFun;
+		}
 		if( cl->fun == fun_var_args ) {
 			cl = (vclosure*)cl->value;
 			return cl->hasValue ? ((vdynamic* (*)(vdynamic*, varray*))cl->fun)(cl->value, args) : ((vdynamic* (*)(varray*))cl->fun)(args);
@@ -228,7 +231,7 @@ HL_PRIM vdynamic *hl_dyn_call( vclosure *c, vdynamic **args, int nargs ) {
 	tmp.a.t = &hlt_array;
 	tmp.a.at = &hlt_dyn;
 	tmp.a.size = nargs;
-	if( c->hasValue && c->t->fun->nargs >= 0 ) {
+	if( c->hasValue && c->t->fun->nargs >= 0 && c->t->fun->parent != NULL ) {
 		ctmp.t = c->t->fun->parent;
 		ctmp.hasValue = 0;
 		ctmp.fun = c->fun;


### PR DESCRIPTION
Fixes https://github.com/HaxeFoundation/hashlink/issues/735

I'm not sure if this is the best solution, but I think at least I did not break it more than before.

The problem in the original issue is that a `makeVarArgs` function is cast to another HFUN type before calling it as `Dynamic` (hl_dyn_call). And the other HFUN type does not have a parent, caused access violation.
This will just prevent null parent crash, and then remove wrapper before calling makeVarArgs.