### PR TITLE
Fix OFloat not working for HF32 (again)

### DIFF
--- a/src/jit.c
+++ b/src/jit.c
@@ -3262,7 +3262,7 @@ int hl_jit_function( jit_ctx *ctx, hl_module *m, hl_function *f ) {
 				case HF64:
 				case HF32:
 #					ifdef HL_64
-					op64(ctx,dst->t->kind == HF32 ? MOVSS : MOVSD,alloc_fpu(ctx,dst,false),pcodeaddr(&p,o->p2 * 8 + (dst->t->kind == HF32 ? 4 : 0)));
+					op64(ctx,dst->t->kind == HF32 ? CVTSD2SS : MOVSD,alloc_fpu(ctx,dst,false),pcodeaddr(&p,o->p2 * 8));
 #					else
 					op64(ctx,dst->t->kind == HF32 ? MOVSS : MOVSD,alloc_fpu(ctx,dst,false),paddr(&p,m->code->floats + o->p2));
 #					endif


### PR DESCRIPTION
Fixes https://github.com/HaxeFoundation/haxe/issues/11647

`OFloat` (seems to) read value from `m->code->float`, which are stored as double in the memory. We need to convert it to float, instead of just using part of the value.