### PR TITLE
[sdl] Force window focus on startup for better focus event

### DIFF
--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -542,6 +542,7 @@ HL_PRIM SDL_Window *HL_NAME(win_create_ex)(int x, int y, int width, int height, 
 		SDL_HideWindow(win);
 		SDL_ShowWindow(win);
 	}
+	SDL_RaiseWindow(win); // better first focus lost behavior
 #	endif
 	return win;
 }


### PR DESCRIPTION
When developing a game in relative mouse mode, on startup if I'm clicking other windows (e.g. debugger, browser), sometimes the game's window is not visible/clickable but my mouse is trapped at the center of the screen (caused by SDL only fire a Focus event but not the FocusLost event).
Use in-game shortcut does not help me to leave the relative mouse mode (the window probably does not receive these input event), and I can only leave the situation with Alt-Tab to the game.

The same issue is not present on DirectX, and I observed that DirectX always bring the window to the top at startup. Then I observed that if I force a `SDL_RaiseWindow` on create, the FocusLost event is fired correctly (probably a hack but works correctly in my tests).

Additional notes:
- The issue can occurs even when `SDL_GetWindowFlags(win)` have `SDL_WINDOW_INPUT_FOCUS` on create
- I'm putting it inside `if HL_WIN` because I did not test if the issue is present in other platforms
- I'm not sure if the condition `if( (SDL_GetWindowFlags(win) & SDL_WINDOW_INPUT_FOCUS) == 0 )` is still needed
- Related fix for exception in heaps https://github.com/HeapsIO/heaps/pull/1273