### PR TITLE
[jit] Fix OGetArray pmem2 on cpu32 access violation

### DIFF
--- a/src/jit.c
+++ b/src/jit.c
@@ -3895,7 +3895,7 @@ int hl_jit_function( jit_ctx *ctx, hl_module *m, hl_function *f ) {
 						hl_runtime_obj *rt = hl_get_obj_rt(dst->t);
 						osize = rt->size;
 					}
-					preg *idx = alloc_cpu(ctx, rb, true);
+					preg *idx = alloc_cpu64(ctx, rb, true);
 					op64(ctx, IMUL, idx, pconst(&p,osize));
 					op64(ctx, isRead?MOV:LEA, rdst, pmem2(&p,alloc_cpu(ctx,ra, true)->id,idx->id,1,0));
 					store(ctx,dst,dst->current,false);


### PR DESCRIPTION
We have an access violation when manipulating CArray:
```haxe
var nodes : hl.CArray<TreeNode>;
public function addBody(aabb : AABB, id : BodyID ) : Int {
	var nodeID = addObjectInternal(aabb); // OCall2
	var node = nodes[nodeID]; // OGetThis, OGetArray
	node.bodyID = id; // OSetField, *access violation*
	return nodeID;
}
```

It generates the following assembly without taking into account that only `eax` part is valid for `rb` at this time
```assembly
000076CA9F330126  imul        rax,rax,2Ch
000076CA9F33012A  lea         r8,[rdx+rax]           ; RAX might be invalid (higher part is not 0), EAX = nodeID
000076CA9F33012E  mov         qword ptr [rbp-18h],r8
000076CA9F330132  mov         r9d,dword ptr [rbp+20h]
000076CA9F330136  mov         dword ptr [r8+0Ch],r9d ; *Access violation* with invalid r8
```

This PR fixes it by using a cpu64.