### PR TITLE
[jit] Fix CArray OSetArray (hl.CArray.unsafeSet) not working

### DIFF
--- a/src/jit.c
+++ b/src/jit.c
@@ -3908,14 +3908,31 @@ int hl_jit_function( jit_ctx *ctx, hl_module *m, hl_function *f ) {
 			break;
 		case OSetArray:
 			{
-				preg *rrb = IS_FLOAT(rb) ? alloc_fpu(ctx,rb,true) : alloc_cpu(ctx,rb,true);
 				if( dst->t->kind == HABSTRACT ) {
 					bool isWrite = dst->t->kind != HOBJ && dst->t->kind != HSTRUCT;
 					// can only write pointers
 					if( !isWrite ) ASSERT(1);
-					copy(ctx, pmem2(&p,alloc_cpu(ctx,dst,true)->id,alloc_cpu64(ctx,ra,true)->id,sizeof(void*),0), rrb, rb->size);
-				} else
+					hl_runtime_obj *rt = hl_get_obj_rt(rb->t);
+					preg *pdst = alloc_cpu(ctx,dst,true);
+					preg *pra = alloc_cpu64(ctx,ra,true);
+					preg *prb = alloc_cpu(ctx,rb,true);
+					op64(ctx, IMUL, pra, pconst(&p,rt->size));
+					op64(ctx, ADD, pdst, pra);
+					scratch(pra);
+					preg *tmp = alloc_reg(ctx, RCPU_CALL);
+					int offset = 0;
+					while( offset < rt->size ) {
+						int remain = rt->size - offset;
+						int copy_size = remain >= HL_WSIZE ? HL_WSIZE : (remain >= 4 ? 4 : (remain >= 2 ? 2 : 1));
+						copy(ctx, tmp, pmem(&p, prb->id, offset), copy_size);
+						copy(ctx, pmem(&p, pdst->id, offset), tmp, copy_size);
+						offset += copy_size;
+					}
+					scratch(pdst);
+				} else  {
+					preg *rrb = IS_FLOAT(rb) ? alloc_fpu(ctx,rb,true) : alloc_cpu(ctx,rb,true);
 					copy(ctx, pmem2(&p,alloc_cpu(ctx,dst,true)->id,alloc_cpu64(ctx,ra,true)->id,hl_type_size(rb->t),sizeof(varray)), rrb, rb->size);
+				}
 			}
 			break;
 		case OArraySize:


### PR DESCRIPTION
Fix hl.CArray.unsafeSet in hl/jit. Use a copy struct approach similar to
- https://github.com/HaxeFoundation/hashlink/pull/758 (if the obj is big, we'll probably need some memcpy)

I don't think CArray can contains other things than obj/struct with the haxe fix (was Dyn for struct), but the isRead/isWrite check here help avoid assert/segfault with hl bytecode generated before the haxe side fix.