### PR TITLE
Buffer: unify null print to null

### DIFF
--- a/src/std/buffer.c
+++ b/src/std/buffer.c
@@ -87,7 +87,7 @@ HL_PRIM void hl_buffer_str_sub( hl_buffer *b, const uchar *s, int len ) {
 }
 
 HL_PRIM void hl_buffer_str( hl_buffer *b, const uchar *s ) {
-	if( s ) hl_buffer_str_sub(b,s,(int)ustrlen(s)); else hl_buffer_str_sub(b,USTR("NULL"),4);
+	if( s ) hl_buffer_str_sub(b,s,(int)ustrlen(s)); else hl_buffer_str_sub(b,USTR("null"),4);
 }
 
 HL_PRIM void hl_buffer_cstr( hl_buffer *b, const char *s ) {
@@ -97,7 +97,7 @@ HL_PRIM void hl_buffer_cstr( hl_buffer *b, const char *s ) {
 		hl_from_utf8(out,len,s);
 		hl_buffer_str_sub(b,out,len);
 		free(out);
-	} else hl_buffer_str_sub(b,USTR("NULL"),4);
+	} else hl_buffer_str_sub(b,USTR("null"),4);
 }
 
 HL_PRIM void hl_buffer_char( hl_buffer *b, uchar c ) {


### PR DESCRIPTION
In Buffer.c, when a pointer is null, it can be print as either "NULL" (in `hl_buffer_str`, `hl_buffer_cstr`) or "null" (in `hl_buffer_rec`, `hl_to_string`).

This is not consistent in the following case
- ref https://github.com/HaxeFoundation/haxe/pull/12143

```haxe
class M {
	var __exceptionMessage:String;
	public function new(value:Any) {
		__exceptionMessage = value;
	}
	public function toString():String {
		return null;
	}
}

class Main {
	static function main() {
		var m = new M(null);
		trace(m.toString()); // null
		trace(Std.string(m)); // NULL <- hl_value_to_string(m) -> hl_buffer_rec -> HOBJ toStringFun hl_buffer_str
	}
}
```

This PR unify them and use "null".