### PR TITLE
[hlc] fix hlc_capture_stack not returning total count with empty stack

### DIFF
--- a/src/hlc_main.c
+++ b/src/hlc_main.c
@@ -114,6 +114,14 @@ static uchar *hlc_resolve_symbol( void *addr, uchar *out, int *outSize ) {
 
 static int hlc_capture_stack( void **stack, int size ) {
 	int count = 0;
+#	if defined(HL_WIN_DESKTOP) || defined(HL_LINUX) || defined(HL_MAC)
+	// force return total count when output stack is null
+	static void* tmpstack[HL_EXC_MAX_STACK];
+	if( stack == NULL ) {
+		stack = tmpstack;
+		size = HL_EXC_MAX_STACK;
+	}
+#	endif
 #	ifdef HL_WIN_DESKTOP
 	count = CaptureStackBackTrace(2, size, stack, NULL) - 8; // 8 startup
 #	elif defined(HL_LINUX)


### PR DESCRIPTION
`new haxe.Exception('')` generate a call to `__nativeStack = NativeStackTrace.callStack();`

Which first call `capture_stack` function with `null` to get the total count

https://github.com/HaxeFoundation/hashlink/blob/f1ef2cf01cd6eee0dc35e6b198cd74acd78d2887/src/std/error.c#L167-L171

However it does not work as expected on hl/c (win/mac/linux), which only return at most `size` as count. And `__nativeStack` will receive an 0-length array as result. This PR fixes it.