### PR TITLE
Sys: sys_exe_path Linux use readlink before env _

### DIFF
--- a/src/std/sys.c
+++ b/src/std/sys.c
@@ -608,17 +608,16 @@ HL_PRIM vbyte *hl_sys_exe_path() {
 #elif defined(HL_CONSOLE)
 	return sys_exe_path();
 #else
-	const pchar *p = getenv("_");
-	if( p != NULL )
-		return (vbyte*)pstrdup(p,-1);
-	{
-		pchar path[PATH_MAX];
-		int length = readlink("/proc/self/exe", path, sizeof(path));
-		if( length < 0 )
-			return NULL;
-		path[length] = '\0';
-		return (vbyte*)pstrdup(path,-1);
+	pchar path[PATH_MAX];
+	int length = readlink("/proc/self/exe", path, sizeof(path));
+	if( length < 0 ) {
+		const pchar *p = getenv("_");
+		if( p != NULL )
+			return (vbyte*)pstrdup(p,-1);
+		return NULL;
 	}
+	path[length] = '\0';
+	return (vbyte*)pstrdup(path,-1);
 #endif
 }
 


### PR DESCRIPTION
See
- https://github.com/HaxeFoundation/haxe/pull/12148#issuecomment-2796653301

TLDR: copy the order in hxcpp, so maybe the haxe CI will be happy