### PR TITLE
Buffer: fix Std.string NativeArray<struct> access violation

### DIFF
--- a/src/std/buffer.c
+++ b/src/std/buffer.c
@@ -182,12 +182,14 @@ static void hl_buffer_addr( hl_buffer *b, void *data, hl_type *t, vlist *stack )
 			hl_buffer_str_sub(b,USTR("false"),5);
 		break;
 	case HSTRUCT:
-		hl_type_obj *o = t->obj;
-		if( o->rt == NULL || hl_get_obj_proto(t)->toStringFun == NULL ) {
-			hl_buffer_char(b,'@');
-			hl_buffer_str(b,o->name);
-		} else
-			hl_buffer_str(b,o->rt->toStringFun(*(vdynamic**)data));
+		{
+			hl_type_obj *o = t->obj;
+			if( o->rt == NULL || hl_get_obj_proto(t)->toStringFun == NULL ) {
+				hl_buffer_char(b,'@');
+				hl_buffer_str(b,o->name);
+			} else
+				hl_buffer_str(b,o->rt->toStringFun(*(vdynamic**)data));
+		}
 		break;
 	default:
 		hl_buffer_rec(b, *(vdynamic**)data, stack);

--- a/src/std/buffer.c
+++ b/src/std/buffer.c
@@ -181,6 +181,14 @@ static void hl_buffer_addr( hl_buffer *b, void *data, hl_type *t, vlist *stack )
 		else
 			hl_buffer_str_sub(b,USTR("false"),5);
 		break;
+	case HSTRUCT:
+		hl_type_obj *o = t->obj;
+		if( o->rt == NULL || hl_get_obj_proto(t)->toStringFun == NULL ) {
+			hl_buffer_char(b,'@');
+			hl_buffer_str(b,o->name);
+		} else
+			hl_buffer_str(b,o->rt->toStringFun(*(vdynamic**)data));
+		break;
 	default:
 		hl_buffer_rec(b, *(vdynamic**)data, stack);
 		break;


### PR DESCRIPTION
Repro:

```haxe
@:struct class Point {
	public var x : Int;
	public function new( x : Int ) { this.x = x; }
	public function toString() : String { return 'Point(x=$x)'; }
}
class Main {
	static function main() {
		var nativeArr = new hl.NativeArray<Point>(10);
		for( i in 0...10 ) {
			nativeArr[i] = new Point(20+i);
		}
		trace(nativeArr); // Access violation
	}
}
```