### PR TITLE
[gc] remove `memmove` usage in hl_remove_roots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ x64
 *.a
 *.opendb
 *.VC.db
+.cache
 .vs
 /hl
 /include/sdl

--- a/src/gc.c
+++ b/src/gc.c
@@ -286,7 +286,7 @@ HL_PRIM void hl_remove_root( void *v ) {
 	for(i=gc_roots_count-1;i>=0;i--)
 		if( gc_roots[i] == (void**)v ) {
 			gc_roots_count--;
-			memmove(gc_roots + i, gc_roots + (i+1), (gc_roots_count - i) * sizeof(void*));
+			gc_roots[i] = gc_roots[gc_roots_count];
 			break;
 		}
 	gc_global_lock(false);


### PR DESCRIPTION
because the insertion order of `gc_roots` list doesn't matter it's possible remove the `memmove` usage and just move the last root from the list to the found root position.