### PR TITLE
[dx] Prevent ClipCursor when window have focus but is not foreground

### DIFF
--- a/libs/directx/window.c
+++ b/libs/directx/window.c
@@ -83,7 +83,8 @@ typedef enum {
 	RButton = 8,
 	MButton = 16,
 	XButton1 = 32,
-	XButton2 = 64
+	XButton2 = 64,
+	NotForeground = 128
 } mouse_capture_flags;
 static int disable_capture = 0;
 static bool capture_mouse = false;
@@ -396,6 +397,12 @@ static LRESULT CALLBACK WndProc( HWND wnd, UINT umsg, WPARAM wparam, LPARAM lpar
 		addState(Blur);
 		break;
 	case WM_WINDOWPOSCHANGED:
+		HWND wndFg = GetForegroundWindow();
+		if( wndFg != wnd ) {
+			disable_capture |= NotForeground;
+		} else {
+			disable_capture &= ~NotForeground;
+		}
 		updateClipCursor(wnd);
 		break;
 	case WM_GETMINMAXINFO:


### PR DESCRIPTION
Sometimes, with DX on startup, we can end up in a case where the window have focus but is not foreground (some other window may hide partially or totally the game window).
This PR prevent ClipCursor when the window is not foreground.

An example of repro is:
- click another window during startup
- lock session (Win+L), * it's not necessary but will make the repro 100% in my case
- wait for game to launch
- unlock session *

Note: if `relative_mouse` is set, `WM_INPUT` event is not received by not-foreground window.
Note2: it's possible fake a Focus/Blur event for haxe side, but might have unwanted effect.