### PR TITLE
Check for __customStack on haxe.Exception

### DIFF
--- a/src/hl.h
+++ b/src/hl.h
@@ -642,7 +642,7 @@ HL_API HL_NO_RETURN( void hl_null_access( void ) );
 HL_API void hl_setup_longjump( void *j );
 HL_API void hl_setup_exception( void *resolve_symbol, void *capture_stack );
 HL_API void hl_dump_stack( void );
-HL_API bool hl_maybe_print_custom_stack( vdynamic* ret );
+HL_API bool hl_maybe_print_custom_stack( vdynamic *exc );
 HL_API varray *hl_exception_stack( void );
 HL_API bool hl_detect_debugger( void );
 

--- a/src/hl.h
+++ b/src/hl.h
@@ -642,6 +642,7 @@ HL_API HL_NO_RETURN( void hl_null_access( void ) );
 HL_API void hl_setup_longjump( void *j );
 HL_API void hl_setup_exception( void *resolve_symbol, void *capture_stack );
 HL_API void hl_dump_stack( void );
+HL_API bool hl_maybe_print_custom_stack( vdynamic* ret );
 HL_API varray *hl_exception_stack( void );
 HL_API bool hl_detect_debugger( void );
 

--- a/src/hlc_main.c
+++ b/src/hlc_main.c
@@ -148,6 +148,26 @@ static int throw_handler( int code ) {
 }
 #endif
 
+bool maybe_print_custom_stack( vdynamic* ret ) {
+	hl_type* exct = ret->t;
+	while( exct->kind == HOBJ ) {
+		if( exct->obj->super == NULL ) {
+			if( ucmp(exct->obj->name, USTR("haxe.Exception")) == 0 ) {
+				hl_field_lookup* f = hl_lookup_find(exct->obj->rt->lookup, exct->obj->rt->nlookup, hl_hash_gen(USTR("__customStack"), true));
+				if( f == NULL || f->field_index < 0 ) break;
+				vdynamic* customStack = *(vdynamic**)((char*)(ret) + f->field_index);
+				if( customStack != NULL ) {
+					uprintf(USTR("Custom stack:%s\n"), hl_to_string(customStack));
+					return true;
+				}
+			}
+			break;
+}
+		exct = exct->obj->super;
+	}
+	return false;
+}
+
 #ifdef HL_WIN_DESKTOP
 int wmain(int argc, uchar *argv[]) {
 #else
@@ -171,11 +191,13 @@ int main(int argc, char *argv[]) {
 	cl.fun = hl_entry_point;
 	ret = hl_dyn_call_safe(&cl, NULL, 0, &isExc);
 	if( isExc ) {
-		varray *a = hl_exception_stack();
-		int i;
 		uprintf(USTR("Uncaught exception: %s\n"), hl_to_string(ret));
-		for (i = 0; i<a->size; i++)
-			uprintf(USTR("Called from %s\n"), hl_aptr(a, uchar*)[i]);
+		if( !maybe_print_custom_stack(ret) ) {
+			varray *a = hl_exception_stack();
+			int i;
+			for( i = 0; i < a->size; i++ )
+				uprintf(USTR("Called from %s\n"), hl_aptr(a, uchar*)[i]);
+		}
 	}
 	hl_global_free();
 	sys_global_exit();

--- a/src/hlc_main.c
+++ b/src/hlc_main.c
@@ -148,26 +148,6 @@ static int throw_handler( int code ) {
 }
 #endif
 
-bool maybe_print_custom_stack( vdynamic* ret ) {
-	hl_type* exct = ret->t;
-	while( exct->kind == HOBJ ) {
-		if( exct->obj->super == NULL ) {
-			if( ucmp(exct->obj->name, USTR("haxe.Exception")) == 0 ) {
-				hl_field_lookup* f = hl_lookup_find(exct->obj->rt->lookup, exct->obj->rt->nlookup, hl_hash_gen(USTR("__customStack"), true));
-				if( f == NULL || f->field_index < 0 ) break;
-				vdynamic* customStack = *(vdynamic**)((char*)(ret) + f->field_index);
-				if( customStack != NULL ) {
-					uprintf(USTR("Custom stack:%s\n"), hl_to_string(customStack));
-					return true;
-				}
-			}
-			break;
-}
-		exct = exct->obj->super;
-	}
-	return false;
-}
-
 #ifdef HL_WIN_DESKTOP
 int wmain(int argc, uchar *argv[]) {
 #else
@@ -192,7 +172,7 @@ int main(int argc, char *argv[]) {
 	ret = hl_dyn_call_safe(&cl, NULL, 0, &isExc);
 	if( isExc ) {
 		uprintf(USTR("Uncaught exception: %s\n"), hl_to_string(ret));
-		if( !maybe_print_custom_stack(ret) ) {
+		if( !hl_maybe_print_custom_stack(ret) ) {
 			varray *a = hl_exception_stack();
 			int i;
 			for( i = 0; i < a->size; i++ )

--- a/src/main.c
+++ b/src/main.c
@@ -142,7 +142,7 @@ bool maybe_print_custom_stack(vdynamic* ret) {
 				if (f == NULL || f->field_index < 0) break;
 				vdynamic* customStack = *(vdynamic**)((char*)(ret) + f->field_index);
 				if (customStack != NULL) {
-					uprintf(USTR("%s"), hl_to_string(customStack));
+					uprintf(USTR("%s\n"), hl_to_string(customStack));
 					return true;
 				}
 			}

--- a/src/main.c
+++ b/src/main.c
@@ -133,15 +133,15 @@ static void setup_handler() {
 }
 #endif
 
-bool maybe_print_custom_stack(vdynamic* ret) {
+bool maybe_print_custom_stack( vdynamic* ret ) {
 	hl_type* exct = ret->t;
-	while (exct->kind == HOBJ) {
-		if (exct->obj->super == NULL) {
-			if (ucmp(exct->obj->name, USTR("haxe.Exception")) == 0) {
+	while( exct->kind == HOBJ ) {
+		if( exct->obj->super == NULL ) {
+			if( ucmp(exct->obj->name, USTR("haxe.Exception")) == 0 ) {
 				hl_field_lookup* f = hl_lookup_find(exct->obj->rt->lookup, exct->obj->rt->nlookup, hl_hash_gen(USTR("_hx_customStack"), true));
-				if (f == NULL || f->field_index < 0) break;
+				if( f == NULL || f->field_index < 0 ) break;
 				vdynamic* customStack = *(vdynamic**)((char*)(ret) + f->field_index);
-				if (customStack != NULL) {
+				if( customStack != NULL ) {
 					uprintf(USTR("%s\n"), hl_to_string(customStack));
 					return true;
 				}
@@ -261,10 +261,10 @@ int main(int argc, pchar *argv[]) {
 	hl_profile_end();
 	if( isExc ) {
 		uprintf(USTR("Uncaught exception: %s\n"), hl_to_string(ctx.ret));
-		if (!maybe_print_custom_stack(ctx.ret)) {
+		if( !maybe_print_custom_stack(ctx.ret) ) {
 			varray* a = hl_exception_stack();
 			int i;
-			for (i = 0; i < a->size; i++)
+			for( i = 0; i < a->size; i++ )
 				uprintf(USTR("Called from %s\n"), hl_aptr(a, uchar*)[i]);
 		}
 		hl_debug_break();

--- a/src/main.c
+++ b/src/main.c
@@ -142,7 +142,7 @@ bool maybe_print_custom_stack(vdynamic* ret) {
 				if (f == NULL || f->field_index < 0) break;
 				vdynamic* customStack = *(vdynamic**)((char*)(ret) + f->field_index);
 				if (customStack != NULL) {
-					uprintf(hl_to_string(customStack));
+					uprintf(USTR("%s"), hl_to_string(customStack));
 					return true;
 				}
 			}

--- a/src/main.c
+++ b/src/main.c
@@ -133,26 +133,6 @@ static void setup_handler() {
 }
 #endif
 
-bool maybe_print_custom_stack( vdynamic* ret ) {
-	hl_type* exct = ret->t;
-	while( exct->kind == HOBJ ) {
-		if( exct->obj->super == NULL ) {
-			if( ucmp(exct->obj->name, USTR("haxe.Exception")) == 0 ) {
-				hl_field_lookup* f = hl_lookup_find(exct->obj->rt->lookup, exct->obj->rt->nlookup, hl_hash_gen(USTR("__customStack"), true));
-				if( f == NULL || f->field_index < 0 ) break;
-				vdynamic* customStack = *(vdynamic**)((char*)(ret) + f->field_index);
-				if( customStack != NULL ) {
-					uprintf(USTR("Custom stack:%s\n"), hl_to_string(customStack));
-					return true;
-				}
-			}
-			break;
-		}
-		exct = exct->obj->super;
-	}
-	return false;
-}
-
 #ifdef HL_WIN
 int wmain(int argc, pchar *argv[]) {
 #else
@@ -261,8 +241,8 @@ int main(int argc, pchar *argv[]) {
 	hl_profile_end();
 	if( isExc ) {
 		uprintf(USTR("Uncaught exception: %s\n"), hl_to_string(ctx.ret));
-		if( !maybe_print_custom_stack(ctx.ret) ) {
-			varray* a = hl_exception_stack();
+		if( !hl_maybe_print_custom_stack(ctx.ret) ) {
+			varray *a = hl_exception_stack();
 			int i;
 			for( i = 0; i < a->size; i++ )
 				uprintf(USTR("Called from %s\n"), hl_aptr(a, uchar*)[i]);

--- a/src/main.c
+++ b/src/main.c
@@ -138,11 +138,11 @@ bool maybe_print_custom_stack( vdynamic* ret ) {
 	while( exct->kind == HOBJ ) {
 		if( exct->obj->super == NULL ) {
 			if( ucmp(exct->obj->name, USTR("haxe.Exception")) == 0 ) {
-				hl_field_lookup* f = hl_lookup_find(exct->obj->rt->lookup, exct->obj->rt->nlookup, hl_hash_gen(USTR("_hx_customStack"), true));
+				hl_field_lookup* f = hl_lookup_find(exct->obj->rt->lookup, exct->obj->rt->nlookup, hl_hash_gen(USTR("__customStack"), true));
 				if( f == NULL || f->field_index < 0 ) break;
 				vdynamic* customStack = *(vdynamic**)((char*)(ret) + f->field_index);
 				if( customStack != NULL ) {
-					uprintf(USTR("%s\n"), hl_to_string(customStack));
+					uprintf(USTR("Custom stack:%s\n"), hl_to_string(customStack));
 					return true;
 				}
 			}

--- a/src/std/error.c
+++ b/src/std/error.c
@@ -142,14 +142,14 @@ HL_PRIM void hl_dump_stack() {
 	fflush(stdout);
 }
 
-HL_PRIM bool hl_maybe_print_custom_stack( vdynamic* ret ) {
-	hl_type* exct = ret->t;
-	while( exct->kind == HOBJ ) {
-		if( exct->obj->super == NULL ) {
-			if( ucmp(exct->obj->name, USTR("haxe.Exception")) == 0 ) {
-				hl_field_lookup* f = hl_lookup_find(exct->obj->rt->lookup, exct->obj->rt->nlookup, hl_hash_gen(USTR("__customStack"), true));
+HL_PRIM bool hl_maybe_print_custom_stack( vdynamic *exc ) {
+	hl_type *ot = exc->t;
+	while( ot->kind == HOBJ ) {
+		if( ot->obj->super == NULL ) {
+			if( ucmp(ot->obj->name, USTR("haxe.Exception")) == 0 ) {
+				hl_field_lookup *f = hl_lookup_find(ot->obj->rt->lookup, ot->obj->rt->nlookup, hl_hash_gen(USTR("__customStack"), true));
 				if( f == NULL || f->field_index < 0 ) break;
-				vdynamic* customStack = *(vdynamic**)((char*)(ret) + f->field_index);
+				vdynamic *customStack = *(vdynamic**)((char*)(exc) + f->field_index);
 				if( customStack != NULL ) {
 					uprintf(USTR("%s\n"), hl_to_string(customStack));
 					return true;
@@ -157,7 +157,7 @@ HL_PRIM bool hl_maybe_print_custom_stack( vdynamic* ret ) {
 			}
 			break;
 		}
-		exct = exct->obj->super;
+		ot = ot->obj->super;
 	}
 	return false;
 }


### PR DESCRIPTION
This allows printing custom exception stacks on uncaught exceptions in case we have an instance of `haxe.Exception` which has `_hx_customStack` set. This will be useful for the coroutine implementation.

It's currently broken because `uprintf` should apparently not be used like that (it works for me locally though), but I'm sure Yuxiao can save me!