### PR TITLE
[cmake] Link openal statically on android

### DIFF
--- a/libs/openal/CMakeLists.txt
+++ b/libs/openal/CMakeLists.txt
@@ -21,19 +21,22 @@ elseif(ANDROID)
             -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
             -DANDROID_PLATFORM=${ANDROID_PLATFORM}
             -DANDROID_ABI=${CMAKE_ANDROID_ARCH_ABI}
+            -DLIBTYPE=STATIC
         # INSTALL_BYPRODUCTS in CMake 3.26+
-        BUILD_BYPRODUCTS <INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR}/libopenal.so
+        BUILD_BYPRODUCTS <INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR}/libopenal.a
         DOWNLOAD_EXTRACT_TIMESTAMP true
     )
     ExternalProject_Get_Property(openal-soft INSTALL_DIR)
 
     add_library(openal SHARED IMPORTED)
-    set_target_properties(openal PROPERTIES IMPORTED_LOCATION ${INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/libopenal.so)
+    set_target_properties(openal PROPERTIES IMPORTED_LOCATION ${INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/libopenal.a)
 
     set(OPENAL_INCLUDE_DIR ${INSTALL_DIR}/${CMAKE_INSTALL_INCLUDEDIR})
     set(OPENAL_LIBRARY openal)
 
     add_dependencies(openal openal-soft)
+
+    target_compile_definitions(openal.hdll PRIVATE OPENAL_STATIC)
 else()
     find_package(OpenAL REQUIRED)
 endif()

--- a/libs/openal/openal.c
+++ b/libs/openal/openal.c
@@ -2,6 +2,11 @@
 #include <hl.h>
 #undef _GUID
 
+#ifdef OPENAL_STATIC
+#define AL_LIBTYPE_STATIC
+#define AL_ALEXT_PROTOTYPES
+#endif
+
 #if defined(__APPLE__) && !defined(openal_soft)
 	#include <OpenAL/al.h>
 	#include <OpenAL/alc.h>
@@ -15,9 +20,11 @@
 // ALC
 // ----------------------------------------------------------------------------
 
+#ifndef OPENAL_STATIC
 #define ALC_IMPORT(fun, t) t fun
 #include "ALCImports.h"
 #undef ALC_IMPORT
+#endif
 
 // Context management
 
@@ -69,7 +76,9 @@ HL_PRIM int HL_NAME(alc_get_error)(ALCdevice *device) {
 
 #define ALC_IMPORT(fun,t) fun = (t)alcGetProcAddress(device,#fun)
 HL_PRIM void HL_NAME(alc_load_extensions)(ALCdevice *device) {
+#ifndef OPENAL_STATIC
 #	include "ALCImports.h"
+#endif
 }
 
 HL_PRIM bool HL_NAME(alc_is_extension_present)(ALCdevice *device, vbyte *extname) {
@@ -145,9 +154,11 @@ DEFINE_PRIM(_VOID,    alc_capture_samples,      TDEVICE _BYTES _I32);
 // AL
 // ----------------------------------------------------------------------------
 
+#ifndef OPENAL_STATIC
 #define AL_IMPORT(fun, t) t fun
 #include "ALImports.h"
 #undef AL_IMPORT
+#endif
 
 HL_PRIM void HL_NAME(al_doppler_factor)(float value) {
 	alDopplerFactor(value);
@@ -227,7 +238,9 @@ HL_PRIM int HL_NAME(al_get_error)() {
 
 #define AL_IMPORT(fun,t) fun = (t)alGetProcAddress(#fun)
 HL_PRIM void HL_NAME(al_load_extensions)() {
+#ifndef OPENAL_STATIC
 #	include "ALImports.h"
+#endif
 }
 
 


### PR DESCRIPTION
Adds an `OPENAL_STATIC` define which adds support for static linking of openal. This solves #636. It is enabled by default on android, to be consistent with other libraries.