### PR TITLE
[cmake] Link with shared openal again on android

### DIFF
--- a/libs/openal/CMakeLists.txt
+++ b/libs/openal/CMakeLists.txt
@@ -21,22 +21,19 @@ elseif(ANDROID)
             -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
             -DANDROID_PLATFORM=${ANDROID_PLATFORM}
             -DANDROID_ABI=${CMAKE_ANDROID_ARCH_ABI}
-            -DLIBTYPE=STATIC
         # INSTALL_BYPRODUCTS in CMake 3.26+
-        BUILD_BYPRODUCTS <INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR}/libopenal.a
+        BUILD_BYPRODUCTS <INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR}/libopenal.so
         DOWNLOAD_EXTRACT_TIMESTAMP true
     )
     ExternalProject_Get_Property(openal-soft INSTALL_DIR)
 
     add_library(openal SHARED IMPORTED)
-    set_target_properties(openal PROPERTIES IMPORTED_LOCATION ${INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/libopenal.a)
+    set_target_properties(openal PROPERTIES IMPORTED_LOCATION ${INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/libopenal.so)
 
     set(OPENAL_INCLUDE_DIR ${INSTALL_DIR}/${CMAKE_INSTALL_INCLUDEDIR})
     set(OPENAL_LIBRARY openal)
 
     add_dependencies(openal openal-soft)
-
-    target_compile_definitions(openal.hdll PRIVATE OPENAL_STATIC)
 else()
     find_package(OpenAL REQUIRED)
 endif()

--- a/libs/openal/CMakeLists.txt
+++ b/libs/openal/CMakeLists.txt
@@ -1,5 +1,12 @@
 add_library(openal.hdll openal.c)
 
+option(WITH_STATIC_OPENAL "Link openal.hdll to static openal-soft" OFF)
+
+if (WITH_STATIC_OPENAL)
+    target_compile_definitions(openal.hdll PRIVATE OPENAL_STATIC)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX})
+endif()
+
 if(WIN32)
     if(MSVC)
         set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /SAFESEH:NO")
@@ -13,6 +20,13 @@ if(WIN32)
 
     set(OPENAL_INCLUDE_DIR ${INCLUDES_BASE_DIR}/openal/include)
 elseif(ANDROID)
+    if (WITH_STATIC_OPENAL)
+        set(OPENAL_LIBTYPE STATIC)
+        set(OPENAL_LIBSUFFIX ${CMAKE_STATIC_LIBRARY_SUFFIX})
+    else()
+        set(OPENAL_LIBTYPE SHARED)
+        set(OPENAL_LIBSUFFIX ${CMAKE_SHARED_LIBARY_SUFFIX})
+    endif()
 	ExternalProject_Add(openal-soft
         URL https://github.com/kcat/openal-soft/archive/refs/tags/1.24.3.tar.gz
         URL_HASH SHA256=7e1fecdeb45e7f78722b776c5cf30bd33934b961d7fd2a11e0494e064cc631ce
@@ -21,14 +35,15 @@ elseif(ANDROID)
             -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
             -DANDROID_PLATFORM=${ANDROID_PLATFORM}
             -DANDROID_ABI=${CMAKE_ANDROID_ARCH_ABI}
+            -DLIBTYPE=${OPENAL_LIBTYPE}
         # INSTALL_BYPRODUCTS in CMake 3.26+
-        BUILD_BYPRODUCTS <INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR}/libopenal.so
+        BUILD_BYPRODUCTS <INSTALL_DIR>/${CMAKE_INSTALL_LIBDIR}/libopenal${OPENAL_LIBSUFFIX}
         DOWNLOAD_EXTRACT_TIMESTAMP true
     )
     ExternalProject_Get_Property(openal-soft INSTALL_DIR)
 
     add_library(openal SHARED IMPORTED)
-    set_target_properties(openal PROPERTIES IMPORTED_LOCATION ${INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/libopenal.so)
+    set_target_properties(openal PROPERTIES IMPORTED_LOCATION ${INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/libopenal${OPENAL_LIBSUFFIX})
 
     set(OPENAL_INCLUDE_DIR ${INSTALL_DIR}/${CMAKE_INSTALL_INCLUDEDIR})
     set(OPENAL_LIBRARY openal)


### PR DESCRIPTION
openal-soft has an LGPL license, which comes with some additional restrictions which are easier to fulfil when linking dynamically.

https://www.gnu.org/licenses/gpl-faq.en.html#LGPLStaticVsDynamic

It is still useful to have the OPENAL_STATIC flag, in case someone wants to link statically and is able to comply with the restrictions.