### PR TITLE
Fix error handling for automatic hlc builds

### DIFF
--- a/other/haxelib/Run.hx
+++ b/other/haxelib/Run.hx
@@ -62,7 +62,7 @@ class Build {
 						code = 1;
 					}
 				} else {
-					log("vswhere error: " + vswhereProc.stderr.readAll().toString());
+					log("vswhere error: " + vswhereProc.stdout.readAll().toString() + vswhereProc.stderr.readAll().toString());
 					code = vswhereProc.exitCode();
 				}
 				vswhereProc.close();

--- a/other/haxelib/Run.hx
+++ b/other/haxelib/Run.hx
@@ -43,7 +43,7 @@ class Build {
 					"-version", tpl == "vs2019" ? "[16.0,17.0]" : "[17.0,18.0]"
 				]);
 				if( vswhereProc.exitCode() == 0 ) {
-					var msbuildPath = StringTools.trim(vswhereProc.stdout.readLine().toString());
+					var msbuildPath = StringTools.trim(try vswhereProc.stdout.readLine().toString() catch (e:haxe.io.Eof) "");
 					if( msbuildPath.length > 0 ) {
 						var prevCwd = Sys.getCwd();
 						var msbuild = '$msbuildPath\\Current\\Bin\\MSBuild.exe';


### PR DESCRIPTION
When vswhere returns empty output, `.readLine()` throws Eof so we need to handle that properly.
We also need to propagate errors from commands that we run, otherwise we will return success even if the build had errors.