### PR TITLE
[hlc] Fix cli args handling with WINDOWS subsystem

### DIFF
--- a/src/hlc_main.c
+++ b/src/hlc_main.c
@@ -194,7 +194,7 @@ int main(int argc, char *argv[]) {
 }
 
 #if defined(HL_WIN_DESKTOP) && !defined(_CONSOLE)
-int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow) {
+int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR lpCmdLine, int nCmdShow) {
 	return wmain(__argc, __wargv);
 }
 #elif defined(HL_XBS)


### PR DESCRIPTION
`__wargv` is `NULL` when using `WinMain`. If we want it to be not `NULL`, we need to use `wWinMain`.

Closes #454.

We changed from `__argv` to `__wargv` in d255a90a5296975098bb4132b4f1234de934afa6. This was necessary because the pointer conversion when passing `__argv` is not valid, causing garbled output from `hl_sys_args` and compiler errors/warnings.

The `HL_XBS` version doesn't seem correct to me either, but I don't have the means to test that.