### PR TITLE
Fix libc++ char32_t redefinition error in hl.h

### DIFF
--- a/src/hl.h
+++ b/src/hl.h
@@ -249,7 +249,7 @@ HL_API int uvszprintf( uchar *out, int out_size, const uchar *fmt, va_list argli
 #if defined(HL_IOS) || defined(HL_TVOS) || defined(HL_MAC)
 #include <stddef.h>
 #include <stdint.h>
-#if !defined(__cplusplus) || __cplusplus < 201103L
+#if !defined(__cplusplus) || (__cplusplus < 201103L && !defined(_LIBCPP_VERSION))
 typedef uint16_t char16_t;
 typedef uint32_t char32_t;
 #endif


### PR DESCRIPTION
With libc++, if the standard is lower than c++11, char32_t and char16_t are still defined as typedefs, so including hl.h in the same .cpp file as any other system header results in errors like this:

```
lib/hashlink/src/hl.h:254:18: error: typedef redefinition with different types ('uint32_t' (aka 'unsigned int') vs 'char32_t')
typedef uint32_t char32_t;
                 ^
/Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk/usr/include/c++/v1/__config:482:20: note: previous definition is here
typedef __char32_t char32_t;
```