### PR TITLE
Fix compilation with GCC 15

### DIFF
--- a/libs/heaps/renderdoc.c
+++ b/libs/heaps/renderdoc.c
@@ -66,7 +66,7 @@ HL_PRIM int HL_NAME(rdoc_get_num_captures)() {
 HL_PRIM bool HL_NAME(rdoc_get_capture)(int index, vbyte *filename, int *pathlength, int64 *timestamp) {
 	if( rdoc_api == NULL )
 		return false;
-	int ret = rdoc_api->GetCapture(index, (char*)filename, pathlength, timestamp);
+	int ret = rdoc_api->GetCapture(index, (char*)filename, (uint32_t*)pathlength, (uint64_t*)timestamp);
 	return ret == 1 ? true : false;
 }
 

--- a/libs/mysql/osdef.h
+++ b/libs/mysql/osdef.h
@@ -60,11 +60,7 @@
 #	define TARGET_LITTLE_ENDIAN
 #endif
 
-#ifndef true
-#	define true 1
-#	define false 0
-	typedef int bool;
-#endif
+#include <stdbool.h>
 
 #endif
 /* ************************************************************************ */


### PR DESCRIPTION
- GCC 15 does not like implicit `int64 *` -> `uint64_t *` casts
- silence warning about the implicit `int *` -> `uint32_t *` cast
- include stdbool.h instead of manually defining `true`/`false`/`bool`, in C23 mode (which GCC 15 defaults to) these are keywords so compilation would fail when `-std=c11` is not set.