### PR TITLE
[sdl] add Event.modifier

### DIFF
--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -91,6 +91,7 @@ typedef struct {
 	ws_change state;
 	int keyCode;
 	int scanCode;
+	int modifier;
 	bool keyRepeat;
 	int reference;
 	int value;
@@ -187,6 +188,7 @@ HL_PRIM bool HL_NAME(event_loop)( event_data *event ) {
 			event->window = e.key.windowID;
 			event->keyCode = e.key.keysym.sym;
 			event->scanCode = e.key.keysym.scancode;
+			event->modifier = e.key.keysym.mod;
 			event->keyRepeat = e.key.repeat != 0;
 			break;
 		case SDL_KEYUP:
@@ -194,6 +196,7 @@ HL_PRIM bool HL_NAME(event_loop)( event_data *event ) {
 			event->window = e.key.windowID;
 			event->keyCode = e.key.keysym.sym;
 			event->scanCode = e.key.keysym.scancode;
+			event->modifier = e.key.keysym.mod;
 			break;
 		case SDL_SYSWMEVENT:
 			continue;

--- a/libs/sdl/sdl/Event.hx
+++ b/libs/sdl/sdl/Event.hx
@@ -11,6 +11,7 @@ package sdl;
 	public var state : WindowStateChange;
 	public var keyCode : Int;
 	public var scanCode : Int;
+	public var modifier : Int;
 	public var keyRepeat : Bool;
 	public var reference : Int;
 	public var value : Int;


### PR DESCRIPTION
This PR adds `modifier` property to the `sdl.Event` and sets it from `mod` field of the https://wiki.libsdl.org/SDL2/SDL_Keysym.

The set operation is only done for `KeyDown` and `KeyUp` events, because it only makes sense for those two.