### PR TITLE
[dx12] Fix warning about unsigned int conversion

### DIFF
--- a/libs/directx/dx12.cpp
+++ b/libs/directx/dx12.cpp
@@ -29,7 +29,7 @@
 #define DXERR(cmd)	{ HRESULT __ret = cmd; if( __ret == E_OUTOFMEMORY ) return NULL; if( __ret != S_OK ) ReportDxError(__ret,__LINE__); }
 #define CHKERR(cmd) { HRESULT __ret = cmd; if( FAILED(__ret) ) ReportDxError(__ret,__LINE__); }
 
-static int gs_constants[] = {
+static unsigned int gs_constants[] = {
 #ifdef _GAMING_XBOX_XBOXONE
 	D3D12XBOX_TEXTURE_DATA_PITCH_ALIGNMENT,
 #else


### PR DESCRIPTION
Fixes warnings:
```
...\hashlink\libs\directx\dx12.cpp(39,2): warning C4838: conversion from 'unsigned int' to 'int' requires a narrowing conversion
...\hashlink\libs\directx\dx12.cpp(40,2): warning C4838: conversion from 'unsigned int' to 'int' requires a narrowing conversion
```

These come up as errors on stricter compilers like mingw (though, dx12.hdll doesn't link on mingw still).