### PR TITLE
Check for fopen null on gc dump and profile dump

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -1396,6 +1396,12 @@ HL_API void hl_gc_dump_memory( const char *filename ) {
 	gc_stop_world(true);
 	gc_mark();
 	fdump = fopen(filename,"wb");
+	if( fdump == NULL ) {
+		gc_stop_world(false);
+		gc_global_lock(false);
+		hl_error("Failed to open file");
+		return;
+	}
 
 	// header
 	fdump_d("HMD1",4);

--- a/src/profile.c
+++ b/src/profile.c
@@ -426,6 +426,12 @@ static void profile_dump( vbyte* ptr ) {
 
 	char* filename = ptr == NULL ? "hlprofile.dump" : hl_to_utf8((uchar*)ptr);
 	FILE *f = fopen(filename,"wb");
+	if( f == NULL ) {
+		data.profiling_pause--;
+		printf("Failed to open file %s, 0 profile samples saved\n", filename);
+		hl_error("Failed to open file");
+		return;
+	}
 	int version = HL_VERSION;
 	fwrite("PROF",1,4,f);
 	fwrite(&version,1,4,f);
@@ -508,7 +514,7 @@ static void profile_dump( vbyte* ptr ) {
 	write_names(data.olds,f);
 	// done
 	fclose(f);
-	printf("%d profile samples saved\n", samples);
+	printf("%d profile samples saved to %s\n", samples, filename);
 	data.profiling_pause--;
 }
 


### PR DESCRIPTION
Prevent null access when opening invalid file, e.g.

```haxe
	static function main() {
		try {
			hl.Gc.dumpMemory("");
		} catch (e) {
			trace("Dump memory error: " + e);
		}
		hl.Profile.event(-7, "" + 10000); // setup
		hl.Profile.event(-5); // resume all
		haxe.Timer.delay(function() {
			try {
				hl.Profile.event(-6, ""); // dump
			} catch (e) {
				trace("Profile end error: " + e);
			}
		}, 100);
	}
```