### PR TITLE
[ci] remove mac unlink python 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,6 @@ jobs:
         # see https://github.com/Homebrew/homebrew-core/issues/165793#issuecomment-1989441193
         # see https://github.com/Homebrew/brew/blob/master/.github/workflows/tests.yml
         brew unlink python && brew link --overwrite python
-        brew unlink python@3.12 && brew link --overwrite python@3.12
 
     - name: "Install: Required Dev Packages"
       run: |


### PR DESCRIPTION
> Error: No such keg: /opt/homebrew/Cellar/python@3.12

Seems that unlink python 3.12 isn't needed anymore in the workaround