### PR TITLE
Remove PAD_64_VAL from hlc.h

### DIFF
--- a/src/hlc.h
+++ b/src/hlc.h
@@ -25,12 +25,6 @@
 #include <math.h>
 #include <hl.h>
 
-#ifdef HL_64
-#	define PAD_64_VAL	,0
-#else
-#	define PAD_64_VAL
-#endif
-
 #ifdef HLC_BOOT
 
 // undefine some commonly used names that can clash with class/var name


### PR DESCRIPTION
Haxe only used this macro in the Haxe development branch for less than a month in 2016 outside of any official releases.

It was added in:
https://github.com/HaxeFoundation/haxe/commit/8776783923275653cff1be7891df047d9717e222#diff-3f2c398bad220eadd039e136de740887e42145b512add1e72a48b2b8ba99062eR5821

and removed in:
https://github.com/HaxeFoundation/haxe/commit/65705a118c197a06e96f744c3d6ba912b9712c18#diff-3f2c398bad220eadd039e136de740887e42145b512add1e72a48b2b8ba99062eL6011

So it should be fine to remove it.

Similarly to #807, it is best to avoid hlc.h from polluting the namespace.