### PR TITLE
Make struct jit_ctx more debugger friendly

### DIFF
--- a/src/hlmodule.h
+++ b/src/hlmodule.h
@@ -103,7 +103,7 @@ typedef struct {
 	bool large;
 } hl_debug_infos;
 
-typedef struct jit_ctx jit_ctx;
+typedef struct _jit_ctx jit_ctx;
 
 
 typedef struct {

--- a/src/jit.c
+++ b/src/jit.c
@@ -273,7 +273,7 @@ static const int RCPU_SCRATCH_REGS[] = { Eax, Ecx, Edx };
 static preg _unused = { RUNUSED, 0, 0, NULL };
 static preg *UNUSED = &_unused;
 
-struct jit_ctx {
+struct _jit_ctx {
 	union {
 		unsigned char *b;
 		unsigned int *w;


### PR DESCRIPTION
I always need to change `jit_ctx` in order to debug it in Visual Studio, it's probably the time to change it.