### PR TITLE
[jit] Fix UI8/UI16 MOD, when b was placed in Eax/Edx

### DIFF
--- a/src/jit.c
+++ b/src/jit.c
@@ -1719,17 +1719,17 @@ static preg *op_binop( jit_ctx *ctx, vreg *dst, vreg *a, vreg *b, hl_op bop ) {
 		case OUMod:
 			{
 				preg *out = bop == OSMod || bop == OUMod ? REG_AT(Edx) : PEAX;
-				preg *r;
+				preg *r = pb;
 				preg p;
 				int jz, jz1 = 0, jend;
 				if( pa->kind == RCPU && pa->id == Eax ) RLOCK(pa);
 				// ensure b in CPU reg and not in Eax/Edx (for UI8/UI16)
-				if( pb->kind != RCPU || pb->id != Ecx ) {
+				if( pb->kind != RCPU || (pb->id == Eax || pb->id == Edx) ) {
 					scratch(REG_AT(Ecx));
 					scratch(pb);
 					load(ctx,REG_AT(Ecx),b);
+					r = REG_AT(Ecx);
 				}
-				r = REG_AT(Ecx);
 				// integer div 0 => 0
 				op(ctx,TEST,r,r,is64);
 				XJump_small(JZero, jz);


### PR DESCRIPTION
When testing differents hl op in
- https://github.com/HaxeFoundation/haxe/pull/12418

I observed that running `t(a.ui8 % b.ui8 == 18);` 5 times and 2 of them (3rd and 5th) will fail.

In fact, if `b` (UI8 or UI16) was placed in Eax/Edx, it's scratched before `IDIV`. Then, during the `IDIV` operation, `fetch(b)` load 32 bit from the stack, which is wrong.

I choose to force load `b` in `Ecx` (*it can be in any register other than Eax/Edx).