### PR TITLE
[jit] Fix is_ptr for HGUID

### DIFF
--- a/src/hl.h
+++ b/src/hl.h
@@ -636,7 +636,7 @@ HL_API void hl_sys_init();
 
 HL_API double hl_nan( void );
 HL_API bool hl_is_dynamic( hl_type *t );
-#define hl_is_ptr(t)	((t)->kind >= HBYTES)
+HL_API bool hl_is_ptr( hl_type *t );
 HL_API bool hl_same_type( hl_type *a, hl_type *b );
 HL_API bool hl_safe_cast( hl_type *t, hl_type *to );
 

--- a/src/std/types.c
+++ b/src/std/types.c
@@ -187,6 +187,36 @@ HL_PRIM bool hl_is_dynamic( hl_type *t ) {
 	return T_IS_DYNAMIC[t->kind];
 }
 
+HL_PRIM bool hl_is_ptr( hl_type *t ) {
+	static bool T_IS_PTR[] = {
+		false, // HVOID,
+		false, // HI8
+		false, // HI16
+		false, // HI32
+		false, // HI64
+		false, // HF32
+		false, // HF64
+		false, // HBOOL
+		true, // HBYTES
+		true, // HDYN
+		true, // HFUN
+		true, // HOBJ
+		true, // HARRAY
+		true, // HTYPE
+		true, // HREF
+		true, // HVIRTUAL
+		true, // HDYNOBJ
+		true, // HABSTRACT
+		true, // HENUM
+		true, // HNULL
+		true, // HMETHOD
+		true, // HSTRUCT
+		true, // HPACKED
+		false, // HGUID
+	};
+	return T_IS_PTR[t->kind];
+}
+
 HL_PRIM bool hl_safe_cast( hl_type *t, hl_type *to ) {
 	if( t == to )
 		return true;


### PR DESCRIPTION
`is_ptr` is not working correctly for `HGUID`, which cause wrong generation in OToDyn

https://github.com/HaxeFoundation/hashlink/blob/876177fab24bf898bacaf91f65e498f4b560122c/src/jit.c#L3145

see also it's hl2c definition in

https://github.com/HaxeFoundation/haxe/blob/5d4cf46e655edfb59e6902e96764f3d28c5e772f/src/generators/hl2c.ml#L135-L137

Repro:
```haxe
    var g:hl.GUID = 0;
    trace(g); // before: null, but expected 0
```

