### PR TITLE
Remove HGUID/HI64 pair in hl_safe_cast

### DIFF
--- a/src/std/types.c
+++ b/src/std/types.c
@@ -192,17 +192,8 @@ HL_PRIM bool hl_safe_cast( hl_type *t, hl_type *to ) {
 		return true;
 	if( to->kind == HDYN )
 		return hl_is_dynamic(t);
-	if( t->kind != to->kind ) {
-		switch( t->kind ) {
-		case HGUID:
-			return to->kind == HI64;
-		case HI64:
-			return to->kind == HGUID;
-		default:
-			break;
-		}
+	if( t->kind != to->kind )
 		return false;
-	}
 	switch( t->kind ) {
 	case HVIRTUAL:
 		if( to->virt->nfields < t->virt->nfields ) {


### PR DESCRIPTION
~Don't know how to actually repro, but the code seems wrong (found by @Simn )~

Removing the HGUID/HI64 in both Haxe & Hashlink, because it can cause the following situation (it does not work as expected if `v` is local variable, but works if `v` is class member)

```haxe
var v : hl.GUID = haxe.Int64.make(0xF, 1);
t("####-#w##-##&" == Std.string(v)); // does not work as expected, v's register is i64
```




