### PR TITLE
[ci] add dxcompiler.dll, dxil.dll into windows VS build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,6 +174,12 @@ jobs:
             ;;
         esac
 
+    - name: "Download: DirectX binaries for windows + make"
+      if: matrix.target == 'windows' && matrix.build_system != 'cmake' && matrix.build_system != 'cmake-mingw'
+      run: |
+        curl -fsSL --retry 3 --retry-delay 5 -o /tmp/dx.zip https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.8.2505.1/dxc_2025_07_14.zip
+        7z x /tmp/dx.zip -oinclude/dx
+
     - name: "Install: GCC 14"
       if: matrix.build_system == 'makegcc14'
       run: |
@@ -184,7 +190,7 @@ jobs:
           gcc --version
 
     - name: Install haxe
-      uses: krdlab/setup-haxe@f0a0baa8ccdb1fe4fc316c8f30eb3ca77aa4ea4e
+      uses: krdlab/setup-haxe@v2
       with:
         haxe-version: latest
 

--- a/Makefile
+++ b/Makefile
@@ -139,10 +139,12 @@ CC=i686-pc-cygwin-gcc
 BUILD_DIR = Release
 VS_SDL_LIBRARY ?= include/sdl/lib/x86/SDL2.dll
 VS_OPENAL_LIBRARY ?= include/openal/bin/Win32/soft_oal.dll
+VS_DX_LIBRARY ?= include/dx/bin/x86/dxcompiler.dll include/dx/bin/x86/dxil.dll
 else
 BUILD_DIR = x64/Release
 VS_SDL_LIBRARY ?= include/sdl/lib/x64/SDL2.dll
 VS_OPENAL_LIBRARY ?= include/openal/bin/Win64/soft_oal.dll
+VS_DX_LIBRARY ?= include/dx/bin/x64/dxcompiler.dll include/dx/bin/x64/dxil.dll
 endif
 
 ifneq (, $(findstring MINGW64, $(UNAME)))
@@ -359,6 +361,7 @@ release_win:
 	cp $(VS_RUNTIME_LIBRARY) $(PACKAGE_NAME)
 	cp $(VS_SDL_LIBRARY) $(PACKAGE_NAME)
 	cp $(VS_OPENAL_LIBRARY) $(PACKAGE_NAME)/OpenAL32.dll
+	cp $(VS_DX_LIBRARY) $(PACKAGE_NAME)
 	# 7z switches: https://sevenzip.osdn.jp/chm/cmdline/switches/
 	7z a -spf -y -mx9 -bt $(PACKAGE_NAME).zip $(PACKAGE_NAME)
 	rm -rf $(PACKAGE_NAME)


### PR DESCRIPTION
Currently downloaded hl binaries (Windows + make release) allows user to run with SDL but not with DX, this PR add required DX dlls