### PR TITLE
[std] Fix hl_dyni32 for systems with unsigned char

### DIFF
--- a/src/std/cast.c
+++ b/src/std/cast.c
@@ -33,7 +33,7 @@ static vdynamic static_ints[256];
 static bool static_ints_init = false;
 
 static vdynamic *hl_dyni32( int v ) {
-	char b = (char)v;
+	signed char b = (signed char)v;
 	if( b == v ) {
 		if( !static_ints_init ) {
 			int i;


### PR DESCRIPTION
On systems where char is unsigned, this function does not behave correctly, as `(char)255` is equal to `-1`, so `hl_dyni32(255)` returns `-1`.