### PR TITLE
[ci] tmp fix setup-haxe bug with latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -372,7 +372,7 @@ jobs:
     - name: Install haxe
       uses: krdlab/setup-haxe@v2
       with:
-        haxe-version: latest
+        haxe-version: 2026-01-05_development_3aed86e
 
     - name: "Configure: Haxelib"
       run: |


### PR DESCRIPTION
Use the hash of latest haxe instead, for now