### PR TITLE
[profile] fix track alloc cause gc segfault

### DIFF
--- a/src/std/track.c
+++ b/src/std/track.c
@@ -128,7 +128,7 @@ static void init_lock() {
 	hl_thread_info *tinf = hl_get_thread();
 	int flags = tinf->flags;
 	tinf->flags &= ~(HL_TRACK_ALLOC<<HL_TREAD_TRACK_SHIFT);
-	track_lock = hl_mutex_alloc(true);
+	track_lock = hl_mutex_alloc(false);
 	hl_add_root(&track_lock);
 	tinf->flags = flags;
 }


### PR DESCRIPTION
The following code found by Simn with https://github.com/HaxeFoundation/haxe/commit/115e2af9f7949ca179945ee95a42f7bed955bb4c and https://github.com/HaxeFoundation/hxcoro/commit/2d763570f19ba1535b72aa3b51c597b7b0bdd6b9 was causing a stable GC read access violation on t (memory area allocated but not initialized)

https://github.com/HaxeFoundation/hashlink/blob/2dbafef6ac4293232a2dd9740d6283c9c1b3982b/src/gc.c#L744

```haxe
import hxcoro.CoroRun;

function memprofStart() {
    var tmp = hl.Profile.globalBits;
    tmp.set(Alloc);
    hl.Profile.globalBits = tmp;
    hl.Profile.reset();
}

function memprofStop() {
    hl.Profile.dump("memprofCount.dump", false, true);
}

function main() {
    memprofStart();
    final numTasks = 100;
    final stamp = haxe.Timer.milliseconds();
    var racyInt = 0;
    CoroRun.runScoped(node -> {
        for (i in 0...numTasks) {
            node.async(node -> {
                racyInt++;
                var busy = 1000;
                while (busy-- > 0) {
                    hxcoro.Coro.yield();
                }
            });
        }
    });
    trace('numTasks: $numTasks, run-time: ${haxe.Timer.milliseconds() - stamp}ms, racyInt: $racyInt');
    memprofStop();
}
```

It's caused by the `track_lock` mutex allowing gc to run on acquire.
Fix suggested by Nicolas.

