### PR TITLE
[map] fix obj map with enum key check only index

### DIFF
--- a/src/std/maps.c
+++ b/src/std/maps.c
@@ -228,7 +228,6 @@ static vdynamic *hl_hofilter( vdynamic *key ) {
 		case HTYPE:
 		case HABSTRACT:
 		case HREF:
-		case HENUM:
 			key = (vdynamic*)key->v.ptr;
 			break;
 		default:


### PR DESCRIPTION
The following code, by Simn, produce unwanted result

```haxe
import haxe.ds.ObjectMap;

enum E1 {
    A;
}

enum E2 {
    B;
}

function main() {
    var map = new ObjectMap();
    var a:Dynamic = A;
    var b:Dynamic = B;
    map.set(a, 1);
    trace(map.get(b)); // 1, expected null
}
```

It's caused by `hl_hofilter` unwrapping `venum` to a pointer.
However, `venum`'s v contains the index instead of the pointer, and should not be unreferenced

https://github.com/HaxeFoundation/hashlink/blob/4c9b361183d3e400f88ac131d8557abc0e6c188f/src/hl.h#L581-L584

Will add a test to haxe repo later.

