### PR TITLE
[hlprof] fix null access t.name on finished thread

### DIFF
--- a/other/haxelib/hlprof/ProfileGen.hx
+++ b/other/haxelib/hlprof/ProfileGen.hx
@@ -182,7 +182,8 @@ class ProfileGen {
 			var tid = f.readInt32();
 			var tname = f.readString(f.readInt32());
 			var t = hthreads.get(tid);
-			t.name = tname;
+			if( t != null )
+				t.name = tname;
 		}
 
 		f.close();


### PR DESCRIPTION
It happens when
- 1st profile has multiple named thread (e.g. MainThread + Worker1)
- In the mean time, Worker1 finished the work and exit
- 2nd profile no longer have Worker1 (e.g. only MainThread), but the Worker1's name remains in data.olds refs
- Converting 2nd profile dump will cause null access

https://github.com/HaxeFoundation/hashlink/blob/e2b1fa5d435b0940d038ec3c9c15dd86af49d83f/src/profile.c#L538