### PR TITLE
Fix Single large value print empty string

### DIFF
--- a/src/std/buffer.c
+++ b/src/std/buffer.c
@@ -154,7 +154,7 @@ static void hl_buffer_addr( hl_buffer *b, void *data, hl_type *t, vlist *stack )
 		hl_buffer_str_sub(b,buf,usprintf(buf,32,PR_I64,*(int64*)data));
 		break;
 	case HF32:
-		hl_buffer_str_sub(b,buf,usprintf(buf,32,USTR("%.9f"),*(float*)data));
+		hl_buffer_str_sub(b,buf,usprintf(buf,32,USTR("%.9g"),*(float*)data));
 		break;
 	case HF64:
 		hl_buffer_str_sub(b,buf,usprintf(buf,32,USTR("%.17g"),*(double*)data));
@@ -220,7 +220,7 @@ static void hl_buffer_rec( hl_buffer *b, vdynamic *v, vlist *stack ) {
 		hl_buffer_str_sub(b,buf,usprintf(buf,32,PR_I64,v->v.i64));
 		break;
 	case HF32:
-		hl_buffer_str_sub(b,buf,usprintf(buf,32,USTR("%.9f"),v->v.f));
+		hl_buffer_str_sub(b,buf,usprintf(buf,32,USTR("%.9g"),v->v.f));
 		break;
 	case HF64:
 		hl_buffer_str_sub(b,buf,usprintf(buf,32,USTR("%.17g"),v->v.d));


### PR DESCRIPTION
Repro from https://github.com/HaxeFoundation/hashlink/pull/871#issuecomment-3840342237

```haxe
inline final SCALAR_MAX:Single = 3.40282347E+38;

function main() {
	var best = SCALAR_MAX;
	trace(best);
}
```

This printed empty because

https://github.com/HaxeFoundation/hashlink/blob/3b3bdfd72ed1c2540b6d1d452cbf9833190b5f56/src/std/buffer.c#L223

uses `%.9f` and (if `buf` is big enough) generates `340282346638528859811704183484516925440.000000000` and the length > buffer size 32, so the len returned is `-1`.

Change it to use `g` as HF64, it now prints `3.40282347e+38` as expected