### PR TITLE
[hlmem] use Float instead of Int for memstats size

### DIFF
--- a/other/haxelib/hlmem/Memory.hx
+++ b/other/haxelib/hlmem/Memory.hx
@@ -568,9 +568,10 @@ class Memory {
 	public function getMemStats() : MemStats {
 		if( memStats != null )
 			return memStats;
-		var pagesSize = 0, reserved = 0;
-		var used = 0;
-		var fUsed = 0;
+		var pagesSize = 0.;
+		var reserved = 0.;
+		var used = 0.;
+		var fUsed = 0.;
 		for( p in pages ) {
 			pagesSize += p.size;
 			reserved += p.reserved;

--- a/other/haxelib/hlmem/Result.hx
+++ b/other/haxelib/hlmem/Result.hx
@@ -7,13 +7,13 @@ abstract class Result {
 @:structInit
 class MemStats extends Result {
 	public var memFile : String;
-	public var free : Int;
-	public var used : Int;
-	public var filterUsed : Int;
-	public var totalAllocated : Int;
+	public var free : Float;
+	public var used : Float;
+	public var filterUsed : Float;
+	public var totalAllocated : Float;
 	public var gc : Int;
 	public var pagesCount : Int;
-	public var pagesSize : Int;
+	public var pagesSize : Float;
 	public var rootsCount : Int;
 	public var stackCount : Int;
 	public var typesCount : Int;


### PR DESCRIPTION
In case that `used` overflow Int and gives negative result.