### PR TITLE
[hlc] fix capture_stack with small size

### DIFF
--- a/src/hlc_main.c
+++ b/src/hlc_main.c
@@ -128,11 +128,14 @@ static int hlc_capture_stack( void **stack, int size ) {
 	}
 #	endif
 #	ifdef HL_WIN_DESKTOP
-	count = CaptureStackBackTrace(2, size, stack, NULL) - 8; // 8 startup
+	count = CaptureStackBackTrace(2, size, stack, NULL);
+	if( size == HL_EXC_MAX_STACK ) count -= 8; // 8 startup
 #	elif defined(HL_LINUX_BACKTRACE)
-	count = backtrace(stack, size) - 8;
+	count = backtrace(stack, size);
+	if( size == HL_EXC_MAX_STACK ) count -= 8;
 #	elif defined(HL_MAC)
-	count = backtrace(stack, size) - 6;
+	count = backtrace(stack, size);
+	if( size == HL_EXC_MAX_STACK ) count -= 6;
 #	endif
 	if( count < 0 ) count = 0;
 	return count;


### PR DESCRIPTION
When tracking alloc in hl/c program, e.g. `hl.Profile.globalBits` set to `Alloc`, `on_alloc` calls `hl_setup.capture_stack` with size `track_depth = 10`:

https://github.com/HaxeFoundation/hashlink/blob/e610c0e1685c632e846bb97755acb58bef8fc7f3/src/std/track.c#L143

With current code, we often get return count 2 (size-8), which doesn't represent the true callstack. The same situation probably happens in `hl_alloc_closure_ptr` too with `hl_setup.closure_stack_capture = 8`:

https://github.com/HaxeFoundation/hashlink/blob/e610c0e1685c632e846bb97755acb58bef8fc7f3/src/std/fun.c#L60

This PR fix this by only do the -8 when size is equal to `HL_EXC_MAX_STACK `.