### PR TITLE
Expose bytes_get_memsize instead of gc for hlc

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -1540,4 +1540,3 @@ DEFINE_PRIM(_DYN, debug_call, _I32 _DYN);
 DEFINE_PRIM(_VOID, blocking, _BOOL);
 DEFINE_PRIM(_VOID, gc_safepoint, _NO_ARG);
 DEFINE_PRIM(_VOID, set_thread_flags, _I32 _I32);
-DEFINE_PRIM(_I32, gc_get_memsize, _BYTES);

--- a/src/std/bytes.c
+++ b/src/std/bytes.c
@@ -280,6 +280,10 @@ HL_PRIM int hl_string_compare( vbyte *a, vbyte *b, int len ) {
 	return memcmp(a,b,len * sizeof(uchar));
 }
 
+HL_PRIM int hl_bytes_get_memsize( vbyte *ptr ) {
+	return hl_gc_get_memsize(ptr);
+}
+
 DEFINE_PRIM(_BYTES,alloc_bytes,_I32);
 DEFINE_PRIM(_VOID,bytes_blit,_BYTES _I32 _BYTES _I32 _I32);
 DEFINE_PRIM(_I32,bytes_compare,_BYTES _I32 _BYTES _I32 _I32);
@@ -299,3 +303,4 @@ DEFINE_PRIM(_I32,bytes_address, _BYTES _REF(_I32));
 DEFINE_PRIM(_BYTES,bytes_from_address, _I32 _I32);
 DEFINE_PRIM(_I64,bytes_address64, _BYTES);
 DEFINE_PRIM(_BYTES,bytes_from_address64, _I64);
+DEFINE_PRIM(_I32, bytes_get_memsize, _BYTES);


### PR DESCRIPTION
gc_get_memsize was exposed recently in https://github.com/HaxeFoundation/hashlink/commit/e2b1fa5d435b0940d038ec3c9c15dd86af49d83f

and referenced in haxe in https://github.com/HaxeFoundation/haxe/commit/4cde34743d2c9d057a83e190aaf28f1862be95de

and fail in hlc for some compilers (repro by @tobil4sk )

```haxe
function main() {
        final bytes = new hl.Bytes(10);
        trace(bytes.getMemSize());
}
```

```
In file included from _Main/Main_Fields_.c:7:
./hl/natives.h:38:12: error: conflicting types for ‘hl_gc_get_memsize’; have ‘int(vbyte *)’ {aka ‘int(unsigned char *)’}
   38 | HL_API int hl_gc_get_memsize(vbyte*);
      |            ^~~~~~~~~~~~~~~~~
In file included from /usr/local/include/hlc.h:26,
                 from _Main/Main_Fields_.c:3:
/usr/local/include/hl.h:807:12: note: previous declaration of ‘hl_gc_get_memsize’ with type ‘int(void *)’
  807 | HL_API int hl_gc_get_memsize( void *ptr );
      |            ^~~~~~~~~~~~~~~~~
make: *** [Makefile:85: _Main/Main_Fields_.o] Error 1
```

Afaik we're not able to expose `void*` to haxe side, and I'm not sure that change definitions in hl.h, gc.c is fine, this PR expose another function `bytes_get_memsize` with the proper signature. Needs also change haxe std.