### PR TITLE
Allow clang-cl compilation under windows

### DIFF
--- a/include/libuv/src/win/atomicops-inl.h
+++ b/include/libuv/src/win/atomicops-inl.h
@@ -26,7 +26,7 @@
 
 
 /* Atomic set operation on char */
-#ifdef _MSC_VER /* MSVC */
+#if defined(_MSC_VER) && !defined(__clang__)/* MSVC */
 
 /* _InterlockedOr8 is supported by MSVC on x32 and x64. It is  slightly less */
 /* efficient than InterlockedExchange, but InterlockedExchange8 does not */

--- a/libs/sdl/gl.c
+++ b/libs/sdl/gl.c
@@ -616,7 +616,7 @@ HL_PRIM void HL_NAME(gl_multi_draw_elements_indirect)( int mode, int type, vbyte
 
 HL_PRIM void HL_NAME(gl_multi_draw_elements_indirect_count)(int mode, int type, vbyte* data, vbyte* drawcount, int maxdrawcount, int stride) {
 	GL_IMPORT_OPT(glMultiDrawElementsIndirectCountARB, MULTIDRAWELEMENTSINDIRECTCOUNTARB)
-	glMultiDrawElementsIndirectCountARB(mode, type, data, (GLintptr)drawcount, maxdrawcount, stride);
+	glMultiDrawElementsIndirectCountARB(mode, type, (GLintptr)data, (GLintptr)drawcount, maxdrawcount, stride);
 }
 
 HL_PRIM int HL_NAME(gl_get_config_parameter)( int feature ) {

--- a/src/hl.h
+++ b/src/hl.h
@@ -186,7 +186,7 @@
 #ifdef HL_64
 #	define HL_WSIZE 8
 #	define IS_64	1
-#	if defined(HL_VCC) || defined(HL_MINGW)
+#	if defined(HL_VCC) || defined(HL_MINGW) || defined(HL_CLANG_CL)
 #		define _PTR_FMT	L"%IX"
 #	else
 #		define _PTR_FMT	u"%lX"
@@ -234,7 +234,7 @@ typedef unsigned long long uint64;
 
 // -------------- UNICODE -----------------------------------
 
-#if defined(HL_WIN) && !defined(HL_LLVM)
+#if defined(HL_VCC) || defined(HL_CLANG_CL)
 #	include <wchar.h>
 typedef wchar_t	uchar;
 #	define USTR(str)	L##str

--- a/src/hl.h
+++ b/src/hl.h
@@ -117,6 +117,10 @@
 #	define HL_CLANG
 #endif
 
+#if defined(_MSC_VER) && defined(__clang__)
+#	define HL_CLANG_CL
+#endif
+
 #if defined(_MSC_VER) && !defined(HL_LLVM)
 #	define HL_VCC
 #	pragma warning(disable:4996) // remove deprecated C API usage warnings
@@ -136,7 +140,7 @@
 #	endif
 #endif
 
-#if defined(HL_VCC) || defined(HL_MINGW) || defined(HL_CYGWIN)
+#if defined(HL_VCC) || defined(HL_MINGW) || defined(HL_CYGWIN) || defined(HL_CLANG_CL)
 #	define HL_WIN_CALL
 #endif
 
@@ -167,7 +171,7 @@
 #	include <stdint.h>
 #endif
 
-#if defined(HL_VCC) || defined(HL_MINGW)
+#if defined(HL_VCC) || defined(HL_MINGW) || defined(HL_CLANG_CL)
 #	define EXPORT __declspec( dllexport )
 #	define IMPORT __declspec( dllimport )
 #else

--- a/src/hlc.h
+++ b/src/hlc.h
@@ -37,6 +37,7 @@
 #undef __SIGN
 #undef INT_MAX
 #undef INT_MIN
+#undef INT16_MAX
 #undef BIG_ENDIAN
 #undef LITTLE_ENDIAN
 #undef OVERFLOW


### PR DESCRIPTION
This PR aims at allowing compilation of hashlink using clang-cl under windows (CLANG based compiler compatible with Microsoft's CL ABI)