### PR TITLE
Update CMake minimum version range

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.13...4.1.2)
 
 set(HL_VERSION_MAJOR 1)
 set(HL_VERSION_MINOR 16)


### PR DESCRIPTION
`cmake` 4.1.2 doesn't support `cmake` less than 3.5 according to the error I get when I try. It seems to build and run fine using 4.1.2 without other changes when allowed.

<details>
<summary>(original cmake error)</summary>

```
Compatibility with CMake < 3.5 has been removed from CMake.

Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
to tell CMake that the project requires at least <min> but has been updated
to work with policies introduced by <max> or earlier.

Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

</details>