### PR TITLE
Fix plugin loading on utf8 path platforms

### DIFF
--- a/src/std/sys.c
+++ b/src/std/sys.c
@@ -173,7 +173,7 @@ HL_PRIM void hl_sys_vtune_init() {
 }
 
 HL_PRIM bool hl_sys_load_plugin( vbyte *file ) {
-#	ifdef HL_UTF8_PATH
+#	ifdef HL_UTF8PATH
 	file = (vbyte*)hl_to_utf8((uchar*)file);
 #	endif
 	return hl_setup.load_plugin && hl_setup.load_plugin((pchar*)file);


### PR DESCRIPTION
`HL_UTF8_PATH` is a typo, the define is `HL_UTF8PATH`: https://github.com/HaxeFoundation/hashlink/blob/d8b1d8e88905cef7dd6937da2a9a1dbbae290f46/src/hl.h#L606