### PR TITLE
Fix usc2 on Windows unknown format IX

### DIFF
--- a/src/hl.h
+++ b/src/hl.h
@@ -181,7 +181,7 @@
 #	define HL_WSIZE 8
 #	define IS_64	1
 #	if defined(HL_VCC) || defined(HL_MINGW)
-#		define _PTR_FMT	L"%IX"
+#		define _PTR_FMT	L"%lX"
 #	else
 #		define _PTR_FMT	u"%lX"
 #	endif
@@ -189,7 +189,7 @@
 #	define HL_WSIZE 4
 #	define IS_64	0
 #	if defined(HL_VCC) || defined(HL_MINGW)
-#		define _PTR_FMT	L"%IX"
+#		define _PTR_FMT	L"%lX"
 #	else
 #		define _PTR_FMT	u"%X"
 #	endif

--- a/src/hl.h
+++ b/src/hl.h
@@ -181,7 +181,7 @@
 #	define HL_WSIZE 8
 #	define IS_64	1
 #	if defined(HL_VCC) || defined(HL_MINGW)
-#		define _PTR_FMT	L"%lX"
+#		define _PTR_FMT	L"%IX"
 #	else
 #		define _PTR_FMT	u"%lX"
 #	endif
@@ -189,7 +189,7 @@
 #	define HL_WSIZE 4
 #	define IS_64	0
 #	if defined(HL_VCC) || defined(HL_MINGW)
-#		define _PTR_FMT	L"%lX"
+#		define _PTR_FMT	L"%IX"
 #	else
 #		define _PTR_FMT	u"%X"
 #	endif

--- a/src/std/ucs2.c
+++ b/src/std/ucs2.c
@@ -221,6 +221,8 @@ sprintf_loop:
 						cfmt[i++] = 0;
 						if( cfmt[i-3] == 'l' )
 							size = sprintf(tmp,cfmt,va_arg(arglist,void*));
+						else if( cfmt[i-3] == 'I' )
+							size = sprintf(tmp,cfmt,va_arg(arglist,size_t));
 						else
 							size = sprintf(tmp,cfmt,va_arg(arglist,int));
 						goto sprintf_add;
@@ -244,6 +246,7 @@ sprintf_loop:
 					case '8':
 					case '9':
 					case 'l':
+					case 'I':
 						break;
 					default:
 						hl_fatal("Unsupported printf format");


### PR DESCRIPTION
Bug introduced by
- https://github.com/HaxeFoundation/hashlink/pull/917

`%IX` isn't recognized anymore.
Ref definition: https://learn.microsoft.com/en-us/cpp/c-runtime-library/format-specification-syntax-printf-and-wprintf-functions?view=msvc-170

Repro:
```haxe
function main() {
	var t = {
		fun : () -> trace("0"),
	}
	trace(t); // Fatal: Unsupported printf format
}
```

Note: Use `size_t`/`ptrdiff_t` print 11 hex digit instead of 8 (I don't know why, they are supposed to be long long?), which aligns with the previous behavior.