### PR TITLE
DX12 Suppress debug warnings

### DIFF
--- a/libs/directx/dx/Dx12.hx
+++ b/libs/directx/dx/Dx12.hx
@@ -1638,6 +1638,22 @@ enum abstract ShaderModel(Int) to Int {
 	public function new() {}
 }
 
+@:struct class InfoQueueFilterDesc {
+	public var numCategories : Int;
+	public var pCategoryList : hl.Bytes;
+	public var numSeverities : Int;
+	public var pSeverityList : hl.Bytes;
+	public var numIDs : Int;
+	public var pIDList : hl.Bytes;
+	public function new() {}
+}
+
+@:struct class InfoQueueFilter {
+	@:packed public var allowList(default, null) : InfoQueueFilterDesc;
+	@:packed public var denyList(default, null) : InfoQueueFilterDesc;
+	public function new() {}
+}
+
 @:hlNative("dx12")
 class Dx12 {
 
@@ -1648,7 +1664,7 @@ class Dx12 {
 	public static function flushMessages() {
 	}
 
-	public static function suppressDebugMessages( ids : hl.Bytes, count : Int ) : Void {
+	public static function suppressDebugMessages( filter : InfoQueueFilter ) : Void {
 	}
 
 	public static function getDescriptorHandleIncrementSize( type : DescriptorHeapType ) : Int {

--- a/libs/directx/dx/Dx12.hx
+++ b/libs/directx/dx/Dx12.hx
@@ -1648,6 +1648,9 @@ class Dx12 {
 	public static function flushMessages() {
 	}
 
+	public static function suppressDebugMessages( ids : hl.Bytes, count : Int ) : Void {
+	}
+
 	public static function getDescriptorHandleIncrementSize( type : DescriptorHeapType ) : Int {
 		return 0;
 	}

--- a/libs/directx/dx12.cpp
+++ b/libs/directx/dx12.cpp
@@ -77,6 +77,17 @@ static LARGE_INTEGER driver_version = {0};
 
 HL_PRIM void dx12_flush_messages();
 
+HL_PRIM void HL_NAME(suppress_debug_messages)(int* ids, int count) {
+#ifndef HL_XBS
+	dx_driver* drv = static_driver;
+	if (!drv->infoQueue) return;
+	D3D12_INFO_QUEUE_FILTER filter = {};
+	filter.DenyList.NumIDs = count;
+	filter.DenyList.pIDList = (D3D12_MESSAGE_ID*)ids;
+	drv->infoQueue->AddStorageFilterEntries(&filter);
+#endif
+}
+
 static void ReportDxError( HRESULT err, int line ) {
 	dx12_flush_messages();
 	hl_error("DXERROR %X line %d",(DWORD)err,line);
@@ -419,6 +430,7 @@ DEFINE_PRIM(_I32, get_current_back_buffer_index, _NO_ARG);
 DEFINE_PRIM(_VOID, signal, _RES _I64);
 DEFINE_PRIM(_VOID, wait, _RES _I64);
 DEFINE_PRIM(_VOID, flush_messages, _NO_ARG);
+DEFINE_PRIM(_VOID, suppress_debug_messages, _BYTES _I32);
 DEFINE_PRIM(_BYTES, get_device_name, _NO_ARG);
 DEFINE_PRIM(_I64, get_timestamp_frequency, _NO_ARG);
 DEFINE_PRIM(_I64, get_driver_version, _NO_ARG);

--- a/libs/directx/dx12.cpp
+++ b/libs/directx/dx12.cpp
@@ -77,14 +77,11 @@ static LARGE_INTEGER driver_version = {0};
 
 HL_PRIM void dx12_flush_messages();
 
-HL_PRIM void HL_NAME(suppress_debug_messages)(int* ids, int count) {
+HL_PRIM void HL_NAME(suppress_debug_messages)(D3D12_INFO_QUEUE_FILTER* filter) {
 #ifndef HL_XBS
 	dx_driver* drv = static_driver;
 	if (!drv->infoQueue) return;
-	D3D12_INFO_QUEUE_FILTER filter = {};
-	filter.DenyList.NumIDs = count;
-	filter.DenyList.pIDList = (D3D12_MESSAGE_ID*)ids;
-	drv->infoQueue->AddStorageFilterEntries(&filter);
+	drv->infoQueue->AddStorageFilterEntries(filter);
 #endif
 }
 
@@ -430,7 +427,7 @@ DEFINE_PRIM(_I32, get_current_back_buffer_index, _NO_ARG);
 DEFINE_PRIM(_VOID, signal, _RES _I64);
 DEFINE_PRIM(_VOID, wait, _RES _I64);
 DEFINE_PRIM(_VOID, flush_messages, _NO_ARG);
-DEFINE_PRIM(_VOID, suppress_debug_messages, _BYTES _I32);
+DEFINE_PRIM(_VOID, suppress_debug_messages, _STRUCT);
 DEFINE_PRIM(_BYTES, get_device_name, _NO_ARG);
 DEFINE_PRIM(_I64, get_timestamp_frequency, _NO_ARG);
 DEFINE_PRIM(_I64, get_driver_version, _NO_ARG);


### PR DESCRIPTION
Add a function which takes an array of Int representing the D3D12_MESSAGE_ID to mute