### PR TITLE
Fix crash when bogus string input is provided to hl_date_from_string

### DIFF
--- a/libs/fmt/fmt.c
+++ b/libs/fmt/fmt.c
@@ -750,7 +750,7 @@ static void md5_finish( md5_context *ctx, uint8 digest[16] ) {
 
 HL_PRIM void HL_NAME(digest)( vbyte *out, vbyte *in, int length, int format ) {
 	if( format & 256 ) {
-		in = (vbyte*)hl_to_utf8((uchar*)in);
+		in = (vbyte*)hl_to_utf8_len((uchar*)in, length);
 		length = (int)strlen((char*)in);
 	}
 	hl_blocking(true);

--- a/src/hl.h
+++ b/src/hl.h
@@ -650,6 +650,7 @@ HL_API vbyte *hl_copy_bytes( const vbyte *byte, int size );
 HL_API int hl_utf8_length( const vbyte *s, int pos );
 HL_API int hl_from_utf8( uchar *out, int outLen, const char *str );
 HL_API char *hl_to_utf8( const uchar *bytes );
+HL_API char *hl_to_utf8_len( const uchar *bytes, int len );
 HL_API uchar *hl_to_utf16( const char *str );
 HL_API uchar *hl_guid_str( int64 guid, uchar buf[14] );
 HL_API vdynamic *hl_virtual_make_value( vvirtual *v );

--- a/src/std/date.c
+++ b/src/std/date.c
@@ -76,7 +76,7 @@ HL_PRIM int hl_date_from_time( double time ) {
 HL_PRIM int hl_date_from_string( vbyte *b, int len ) {
 	struct tm t;
 	int o = 0;
-	const char *str = hl_to_utf8((uchar*)b);
+	const char *str = hl_to_utf8_len((uchar*)b, len);
 	bool recal = true;
 	memset(&t,0,sizeof(struct tm));
 	switch( strlen(str) ) {

--- a/src/std/string.c
+++ b/src/std/string.c
@@ -200,7 +200,7 @@ HL_PRIM vbyte *hl_utf16_to_utf8( vbyte *str, int len, int *size ) {
 	uchar *end = len == 0 ? NULL : c + len;
 	int utf8bytes = 0;
 	int p = 0;
-	while( c != end ) {
+	while( c < end ) {
 		unsigned int v = (unsigned int)*c;
 		if( v == 0 && end == NULL ) break;
 		if( v < 0x80 )
@@ -216,7 +216,7 @@ HL_PRIM vbyte *hl_utf16_to_utf8( vbyte *str, int len, int *size ) {
 	}
 	out = hl_gc_alloc_noptr(utf8bytes + 1);
 	c = (uchar*)str;
-	while( c != end ) {
+	while( c < end ) {
 		unsigned int v = (unsigned int)*c;
 		if( v < 0x80 ) {
 			out[p++] = (vbyte)v;
@@ -244,6 +244,11 @@ HL_PRIM vbyte *hl_utf16_to_utf8( vbyte *str, int len, int *size ) {
 HL_PRIM char *hl_to_utf8( const uchar *bytes ) {
 	int size;
 	return (char*)hl_utf16_to_utf8((vbyte*)bytes, 0, &size);
+}
+
+HL_PRIM char *hl_to_utf8_len( const uchar *bytes, int len ) {
+	int size;
+	return (char*)hl_utf16_to_utf8((vbyte*)bytes, len, &size);
 }
 
 static void hl_buffer_hex( hl_buffer *b, int c ) {


### PR DESCRIPTION
Fix crash when bogus string input is provided to hl_date_from_string or format digest function.

Added a new function in hl.h, hl_to_utf8_len, same as hl_to_utf8 but with a len parameter Updated hl_utf16_to_utf8 to replace '!= end' by '< end' because c can be incremented two times in the loop and it may be an issue with invalid input.

Here is a reproductible example : 

[segfault_fixed_by_utf8_len.txt](https://github.com/user-attachments/files/27279516/segfault_fixed_by_utf8_len.txt)

```haxe
class Main {
    static public function main() {
        final input = Sys.stdin().readLine();
        try {
            var date = Date.fromString(input);
            trace(date);
        } catch (e:haxe.Exception) {
        }
    }
}
```

```
$ haxe -main Main -hl out.hl
$ hl out.hl < segfault_fixed_by_utf8_len.txt
SIGNAL 11[Segmentation fault]
$Date.fromString(/usr/share/haxe/std/hl/_std/Date.hx:157)
$ParseDate.main(ParseDate.hx:5)
.init(?:1)
[1]    2231895 segmentation fault
```

Here is the reproductible example for Shadigest (with the same input):
```
import haxe.crypto.Sha1;

class Main {
    static function main() {
        final input = Sys.stdin().readLine();
        try {
            trace(Sha1.encode(input));
        } catch (e:haxe.Exception) {
        }
    }
}
```

```
$ haxe -main Main -hl out.hl
$ hl out.hl < segfault_fixed_by_utf8_len.txt
SIGNAL 11[Segmentation fault]
haxe.crypto.$Sha1.encode(/usr/share/haxe/std/hl/_std/haxe/crypto/Sha1.hx:28)
$Main.main(Main.hx:8)
.init(?:1)
[1]    2671945 segmentation fault
```
I found this issue with AFL++ by trying fuzzing on some Haxe std function. Don't hesitate to ask if you need more details (I kept some notes during the debugging process, but it's in french). 

I didn't used any LLM in the entire process from writting Haxe script or fixes or this PR.
Have a nice day !