### PR TITLE
Fix macOS Homebrew package install in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,7 +167,7 @@ jobs:
           darwin)
             if [ "${{matrix.build_system}}" != "cmake" ]; then
               brew update
-              brew bundle
+              HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew bundle --no-upgrade
             fi
             ;;
 
@@ -425,6 +425,8 @@ jobs:
 
   haxe-test-suite:
     needs: build
+    env:
+      HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fixes macOS CI failures caused by Homebrew upgrading installed dependents while installing required packages.

Sets HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 for macOS brew installs so unrelated runner packages like python@3.13 are not upgraded during the build.