### PR TITLE
Fix Reflect.compare on overflow values

### DIFF
--- a/src/std/cast.c
+++ b/src/std/cast.c
@@ -426,13 +426,15 @@ HL_PRIM int hl_dyn_compare( vdynamic *a, vdynamic *b ) {
 		return (int)a->v.ui16 - (int)b->v.ui16;
 	case TK2(HI32,HI32):
 		{
-			int d = a->v.i - b->v.i;
-			return d == hl_invalid_comparison ? -1 : d;
+			int ia = a->v.i;
+			int ib = b->v.i;
+			return ia == ib ? 0 : (ia > ib ? 1 : -1);
 		}
 	case TK2(HI64,HI64):
 		{
-			int64 d = a->v.i64 - b->v.i64;
-			return d == 0 ? 0 : (d > 0 ? 1 : -1);
+			int64 ia = a->v.i64;
+			int64 ib = b->v.i64;
+			return ia == ib ? 0 : (ia > ib ? 1 : -1);
 		}
 	case TK2(HF32,HF32):
 		return fcompare(a->v.f,b->v.f);


### PR DESCRIPTION
Fixes #939 and its i64 variant

```haxe
function main() {
	var a = 2147483640;
	var b = -2147483641;
	trace(Reflect.compare(a, b)); // was -15, expected > 0, after fix 1

	var a = haxe.Int64.make(0x7FFFFFFF, 0xFFFFFFF8); // 9223372036854775800
	var b = haxe.Int64.make(0x80000000, 0x00000007); // -9223372036854775801
	trace(Reflect.compare(a, b)); // was -1, expected > 0, after fix 1
}
```