### PR TITLE
[CI] use gh instead of curl for api call

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -541,13 +541,15 @@ jobs:
     - name: Get Haxe commit SHA
       id: haxe_sha
       shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         version=$(haxe --version)
-        short_sha=${version##*+}
-        full_sha=$(curl -fsSL "https://api.github.com/repos/HaxeFoundation/haxe/commits/$short_sha" | jq -r '.sha')
-        echo "sha=$full_sha" >> "$GITHUB_OUTPUT"
         echo "Haxe version: $version"
+        short_sha=${version##*+}
+        full_sha=$(gh api repos/HaxeFoundation/haxe/commits/$short_sha --jq '.sha')
         echo "Commit SHA: $short_sha, Full SHA: $full_sha"
+        echo "sha=$full_sha" >> "$GITHUB_OUTPUT"
 
     - uses: actions/checkout@v6
       with:


### PR DESCRIPTION
Otherwise we might run into rate limit

```
curl: (22) The requested URL returned error: 403
```