### PR TITLE
[plugin] fix Std.isOfType safecast on loaded type

### DIFF
--- a/src/std/types.c
+++ b/src/std/types.c
@@ -244,7 +244,7 @@ HL_PRIM bool hl_safe_cast( hl_type *t, hl_type *to ) {
 			hl_type_obj *o = t->obj;
 			hl_type_obj *oto = to->obj;
 			while( true ) {
-				if( o == oto ) return true;
+				if( o == oto || o->name == oto->name ) return true;
 				if( o->super == NULL ) return false;
 				o = o->super->obj;
 			}


### PR DESCRIPTION
For https://github.com/HaxeFoundation/hashlink/issues/945

Similar fix to `t1->name == t2->name` in `hl_dyn_castp` (https://github.com/HaxeFoundation/hashlink/commit/d271f4c252701b5284906d962488df6f37a7e27a)
