### PR TITLE
[plugin] fix load struct

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -121,7 +121,7 @@ static bool load_plugin( pchar *file ) {
 	int i;
 	for(i=0;i<code->ntypes;i++) {
 		hl_type *t1 = code->types + i;
-		if( t1->kind != HOBJ ) continue;
+		if( t1->kind != HOBJ && t1->kind != HSTRUCT ) continue;
 		hl_type *t2 = hl_module_resolve_type(main_ctx->m, t1, false);
 		// ensure that cast will work between types !
 		if( t2 ) t1->obj->name = t2->obj->name;
@@ -142,7 +142,7 @@ static bool load_plugin( pchar *file ) {
 
 static vdynamic *resolve_type( hl_type *t, hl_type *gt ) {
 	hl_type *t2 = hl_module_resolve_type(main_ctx->m, t, true);
-	if( t2 == NULL || t2->kind != HOBJ )
+	if( t2 == NULL || (t2->kind != HOBJ && t2->kind != HSTRUCT))
 		return NULL;
 	hl_module_context *m = t->obj->m;
 	hl_module_context *m2 = t2->obj->m;

--- a/src/module.c
+++ b/src/module.c
@@ -807,11 +807,11 @@ static int check_same_obj( hl_type_obj *o1, hl_type_obj *o2 ) {
 
 hl_type *hl_module_resolve_type( hl_module *m, hl_type *t, bool err ) {
 	int i;
-	if( t->kind != HOBJ )
+	if( t->kind != HOBJ && t->kind != HSTRUCT )
 		return NULL;
 	for(i=0;i<m->code->ntypes;i++) {
 		hl_type *t2 = m->code->types + i;
-		if( t2->kind == HOBJ && ucmp(t->obj->name,t2->obj->name) == 0 ) {
+		if( t2->kind == t->kind && ucmp(t->obj->name,t2->obj->name) == 0 ) {
 			int r = check_same_obj(t->obj,t2->obj);
 			if( r == 0 )
 				return t2;


### PR DESCRIPTION
Fix "Imported type 'SharedStruct' could not be resolved".

Repro: run with `haxe build.hxml && haxe plugin.hxml && hl test.hl`

```haxe
// Main.hx
class Main {
	static function main() {
		hl.Api.loadPlugin("plugin.hl");
	}
}

@:struct
class SharedStruct {
	public var value:Int;
	public var name:String;
	public function new(value:Int, name:String) {
		this.value = value;
		this.name = name;
	}
	public function sum(v:Int):Int {
		return value + v;
	}
}
```

```haxe
// Plugin.hx
class Plugin {
	static function main() {
		struct_resolve();
	}
	static function struct_resolve() {
		var s = new Main.SharedStruct(10, "hello");
		eq(s.value, 10);
		t(Std.isOfType(s, Main.SharedStruct));
	}
	static inline function eq<T>(actual:T, expected:T, ?infos:haxe.PosInfos) {
		if (actual != expected)
			haxe.Log.trace('FAIL: $actual, expected=$expected', infos);
		else
			haxe.Log.trace('OK: $actual', infos);
	}
	static inline function t(actual:Bool) {
		eq(actual, true);
	}
}
```

```hxml
// build.hxml
--main Main
-D hl-check
--hl test.hl
```

```hxml
// Plugin.hxml
-hl plugin.hl
-main Plugin
--macro exclude("SharedStruct")
```