### PR TITLE
profile.c: fix x86 register names leaking onto aarch64 (Linux/Android)

### DIFF
--- a/src/profile.c
+++ b/src/profile.c
@@ -145,7 +145,7 @@ static void *get_thread_stackptr( thread_handle *t, void **eip ) {
 	*eip = (void*)c.Eip;
 	return (void*)c.Esp;
 #	endif
-#elif defined(HL_LINUX)
+#elif defined(HL_LINUX) && (defined(__x86_64__) || defined(__i386__))
 #	ifdef HL_64
 	*eip = (void*)shared_context.context.uc_mcontext.gregs[REG_RIP];
 	return (void*)shared_context.context.uc_mcontext.gregs[REG_RSP];
@@ -153,6 +153,10 @@ static void *get_thread_stackptr( thread_handle *t, void **eip ) {
 	*eip = (void*)shared_context.context.uc_mcontext.gregs[REG_EIP];
 	return (void*)shared_context.context.uc_mcontext.gregs[REG_ESP];
 #	endif
+#elif defined(HL_LINUX) && defined(__aarch64__)
+	// Linux/Android ARM64: uc_mcontext has direct regs[] / sp / pc fields.
+	*eip = (void*)shared_context.context.uc_mcontext.pc;
+	return (void*)shared_context.context.uc_mcontext.sp;
 #elif defined(HL_MAC) && defined(__x86_64__)
 	struct __darwin_mcontext64 *mcontext = shared_context.context.uc_mcontext;
 	if (mcontext != NULL) {


### PR DESCRIPTION
On Linux, `get_thread_stackptr()` read `REG_RIP` / `REG_RSP` from `ucontext_t.uc_mcontext.gregs[]`, which only exist on x86. On AArch64 Linux (including Android), `uc_mcontext` is a `struct sigcontext` with direct `pc` / `sp` / `regs[]` fields and no `gregs[]` member, so the file failed to compile.

Two changes:
- The existing `HL_LINUX` branch is now scoped to `x86_64` / `i386` explicitly.
- A new `HL_LINUX && __aarch64__` branch reads `.pc` / `.sp` directly from `uc_mcontext`.

Independent of any JIT work; unblocks compiling hl/libhl on aarch64 Linux and through the Android NDK. No behaviour change on x86.