### PR TITLE
libs/sdl: build on Android / GL ES (glColorMaski stub + SDL_SetMainReady)

### DIFF
--- a/libs/sdl/gl.c
+++ b/libs/sdl/gl.c
@@ -46,6 +46,7 @@
 #	define glPolygonMode(face,mode) if( mode != 0x1B02 ) ES_NOT_SUPPORTED
 #	define glGetQueryObjectiv glGetQueryObjectuiv
 #	define glClearDepth glClearDepthf
+#	define glColorMaski(...) ES_NOT_SUPPORTED
 #endif
 
 #if !defined(HL_CONSOLE) && !defined(GL_IMPORT)

--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -7,6 +7,12 @@
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_gamepad.h>
 
+#ifdef HL_ANDROID
+// SDL3 no longer pulls SDL_main.h (where SDL_SetMainReady lives) in via SDL.h.
+#	define SDL_MAIN_HANDLED
+#	include <SDL3/SDL_main.h>
+#endif
+
 #if defined (HL_IOS) || defined(HL_TVOS)
 #	include <OpenGLES/ES3/gl.h>
 #	include <OpenGLES/ES3/glext.h>
@@ -102,6 +108,10 @@ static bool isGlOptionsSet = false;
 
 HL_PRIM bool HL_NAME(init_once)() {
 	SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
+#	ifdef HL_ANDROID
+	// Pure HL binary has no Activity/SDL_main; tell SDL init was set up
+	SDL_SetMainReady();
+#	endif
 	if( !SDL_Init( SDL_INIT_AUDIO | SDL_INIT_VIDEO | SDL_INIT_GAMEPAD ) ) {
 		hl_error("SDL_Init failed: %s", hl_to_utf16(SDL_GetError()));
 		return false;


### PR DESCRIPTION
Two small fixes to build the SDL/GL bindings on Android arm64 (GL ES):

- `gl.c`: stub `glColorMaski` to `ES_NOT_SUPPORTED` — GL ES has no per-MRT colour mask, so the call can't be expressed there. Keeps the desktop path untouched.
- `sdl.c`: call `SDL_SetMainReady()` under `#ifdef __ANDROID__` before `SDL_Init`, so a pure HL/native binary (not wrapped in an Android Activity) doesn't trip SDL's `SDL_main` check.

Both are guarded by GL ES / `__ANDROID__` and have no effect on desktop targets. Rebased onto the current SDL3 master.