### PR TITLE
ui_win: fix invocation of sentinel callback

### DIFF
--- a/libs/ui/ui_win.c
+++ b/libs/ui/ui_win.c
@@ -228,14 +228,14 @@ static void sentinel_loop( vsentinel *s ) {
 				// simulate a call
 #				ifdef HL_64
 				int_val* rsp = (int_val*)regs.Rsp;
+				// ensure the stack is aligned to 16 bytes 
+				rsp = (int_val*)((int_val)rsp & ~15);
 				*--rsp = (int_val)regs.Rip;
-				*--rsp = (int_val)rsp;
 				regs.Rsp = (int_val)rsp;
 				regs.Rip = (int_val)s->callback;
 #				else
 				int_val* esp = (int_val*)regs.Esp;
 				*--esp = (int_val)regs.Eip;
-				*--esp = (int_val)esp;
 				regs.Esp = (int_val)esp;
 				regs.Eip = (int_val)s->callback;
 #				endif


### PR DESCRIPTION
Fixes the issue described by @yuxiaomao in https://github.com/HaxeFoundation/hashlink/pull/902#issuecomment-4853286625

To simulate a call the stack (prior to pushing the return address) needs to be aligned to 16 bytes to respect the x64 calling convention, and only the return address should be pushed.