### PR TITLE
Prevent segfault on process termination with threads

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -314,12 +314,12 @@ int main(int argc, pchar *argv[]) {
 #endif
 		return 1;
 	}
-	hl_module_free(ctx.m);
-	hl_free(&ctx.code->alloc);
 #ifdef HL_THREADS
 	// other threads may still be running and crash if globals are freed, so only run a gc here
 	hl_gc_major();
 #else
+	hl_module_free(ctx.m);
+	hl_free(&ctx.code->alloc);
 	hl_global_free();
 #endif
 	return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -307,7 +307,7 @@ int main(int argc, pchar *argv[]) {
 	if( isExc ) {
 		hl_print_uncaught_exception(ctx.ret);
 		hl_debug_break();
-		hl_global_free();
+		// skip hl_global_free(): background threads may still be running and access the HL runtime
 		return 1;
 	}
 	hl_module_free(ctx.m);

--- a/src/main.c
+++ b/src/main.c
@@ -307,14 +307,23 @@ int main(int argc, pchar *argv[]) {
 	if( isExc ) {
 		hl_print_uncaught_exception(ctx.ret);
 		hl_debug_break();
-		// skip hl_global_free(): background threads may still be running and access the HL runtime
+#ifdef HL_THREADS
+		hl_gc_major();
+#else
+		hl_global_free();
+#endif
 		return 1;
 	}
 	hl_module_free(ctx.m);
 	hl_free(&ctx.code->alloc);
+#ifdef HL_THREADS
+	// other threads may crash if globals are freed, so only run a gc major here
+	hl_gc_major();
+#else
 	// do not call hl_unregister_thread() or hl_global_free will display error
 	// on global_lock if there are threads that are still running (such as debugger)
 	hl_global_free();
+#endif
 	return 0;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -317,11 +317,9 @@ int main(int argc, pchar *argv[]) {
 	hl_module_free(ctx.m);
 	hl_free(&ctx.code->alloc);
 #ifdef HL_THREADS
-	// other threads may crash if globals are freed, so only run a gc major here
+	// other threads may still be running and crash if globals are freed, so only run a gc here
 	hl_gc_major();
 #else
-	// do not call hl_unregister_thread() or hl_global_free will display error
-	// on global_lock if there are threads that are still running (such as debugger)
 	hl_global_free();
 #endif
 	return 0;


### PR DESCRIPTION
I discovered the situation when debugging on Linux, the program have a few hashlink threads and some Steam worker threads:

Basically after an "Uncaught exception", the program sometimes exit 1 successfully, sometimes got segmentation fault / double free error, sometimes crash in Steam's worker thread (which may or may not be related). Here is one of the segfault that have meaningful stack:

```
// Previously Uncaught exception XXXX (and it's stack, and SIGTRAP from hl_debug_break)
Thread 16 "shiroSysAsync" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffebffe6c0 (LWP 112219)]
hl_mutex_acquire (l=0x0) at src/std/thread.c:148

// bt
#0 hl_mutex_acquire (l=0x0) at src/std/thread.c:148 No locals.
#1 0x00007ffff7c63b97 in hl_hash_gen (name=<optimized out>, cache_name=<optimized out>) at src/std/obj.c:111
```

This indicate that `hl_cache_lock` is freed by the GC, but another thread tried to access it (probably the asyc exception logger in this case):

https://github.com/HaxeFoundation/hashlink/blob/64899c10173ec655f4cb3a6dce92c58c9aa662f9/src/std/obj.c#L101-L112

Remove `hl_global_free` in `main.c` isExc path seems to prevent exception inside hashlink, but we can still get segmentation fault inside `steamclient.so` during exit cleanup. Add a `_Exit(1)` to force termination of all threads immediatly prevent the exception inside `steamclient.so` too.

https://github.com/HaxeFoundation/hashlink/blob/64899c10173ec655f4cb3a6dce92c58c9aa662f9/src/main.c#L304-L312

I'm not sure if this is the correct fix though.