### PR TITLE
Fix uprintf not working on XBS

### DIFF
--- a/src/std/sys.c
+++ b/src/std/sys.c
@@ -143,9 +143,6 @@ HL_PRIM int hl_sys_set_flags( int flags ) {
 
 HL_PRIM void hl_sys_print( vbyte *msg ) {
 	hl_blocking(true);
-#	if defined(HL_XBO) || defined(HL_XBS)
-	OutputDebugStringW((LPCWSTR)msg);
-#	else
 #	ifdef HL_WIN_DESKTOP
 	if( print_flags & PR_WIN_UTF8 ) _setmode(_fileno(stdout),_O_U8TEXT);
 #	endif
@@ -153,8 +150,6 @@ HL_PRIM void hl_sys_print( vbyte *msg ) {
 	if( print_flags & PR_AUTO_FLUSH ) fflush(stdout);
 #	ifdef HL_WIN_DESKTOP
 	if( print_flags & PR_WIN_UTF8 ) _setmode(_fileno(stdout),_O_TEXT);
-#	endif
-
 #	endif
 	hl_blocking(false);
 }

--- a/src/std/ucs2.c
+++ b/src/std/ucs2.c
@@ -22,6 +22,9 @@
 #include <hl.h>
 #include <stdarg.h>
 
+#ifdef HL_CONSOLE
+#	include <posix/posix.h>
+#endif
 #ifdef HL_ANDROID
 #	include <android/log.h>
 #	ifndef HL_ANDROID_LOG_TAG
@@ -163,6 +166,13 @@ static char *utos( const uchar *s ) {
 }
 
 void uprintf( const uchar *fmt, const uchar *str ) {
+#if defined(HL_XBO) || defined(HL_XBS)
+	int size = ustrlen(fmt) + ustrlen(str) + 1;
+	uchar *buffer = malloc(size * sizeof(uchar));
+	usprintf(buffer, size, fmt, str);
+	OutputDebugStringW((LPCWSTR)buffer);
+	free(buffer);
+#else
 	char *cfmt = utos(fmt);
 	char *cstr = utos(str);
 #ifdef HL_ANDROID
@@ -172,6 +182,7 @@ void uprintf( const uchar *fmt, const uchar *str ) {
 #endif
 	free(cfmt);
 	free(cstr);
+#endif
 }
 
 #ifdef HL_VCC


### PR DESCRIPTION
`uprintf` is used in uncaught exception stack print (code below), so it's useful to get that in log.
The buffer size is estimated, but should works with a single `%s`, and at least we have some data. 

https://github.com/HaxeFoundation/hashlink/blob/64899c10173ec655f4cb3a6dce92c58c9aa662f9/src/std/error.c#L159-L167

