### PR TITLE
SDL3 File Dialogs

### DIFF
--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -1203,7 +1203,7 @@ void FileDialogCallback(void *userdata, const char* const *filelist, int filter)
 	dialog_data *data = (dialog_data*)userdata;
 	int count = 0;
 
-	varray *array;
+	varray *array = NULL;
 	if( filelist ) {
 		const char * const *p = filelist;
 		while(*p++)
@@ -1218,8 +1218,6 @@ void FileDialogCallback(void *userdata, const char* const *filelist, int filter)
 			memcpy(bytes, filelist[i], len);
 			array_ptr[i] = bytes;
 		}
-	} else {
-		array = hl_alloc_array(&hlt_bytes, 0 );
 	}
 
 	hl_call1( void, data->closure, varray*, array );

--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -1163,14 +1163,12 @@ typedef struct {
 	SDL_DialogFileFilter* filters;
 } dialog_data;
 
-dialog_data* CreateFileDialogData( vclosure *callback, varray *filters )
-{
+dialog_data* CreateFileDialogData( vclosure *callback, varray *filters ) {
 	dialog_data *data = malloc( sizeof( dialog_data ) );
 	data->closure_store = malloc(sizeof(vclosure*));
 	*data->closure_store = callback;
 
-	if( filters && filters->size > 0 )
-	{
+	if( filters && filters->size > 0 ) {
 		SDL_DialogFileFilter *sdl_filters = (SDL_DialogFileFilter *)malloc(sizeof( SDL_DialogFileFilter ) * filters->size );
 
 		for(int i=0;i<filters->size;i++) {

--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -1160,20 +1160,19 @@ DEFINE_PRIM(_BYTES, get_error, _NO_ARG);
 // SDL Dialogs API
 void FileDialogCallback(void *userdata, const char* const *filelist, int filter) {
 	// these callbacks may come via threads on some platforms
-	bool on_thread = !hl_get_thread();
-	if( on_thread )
-	{
-		vdynamic* ctx;
+	bool on_unregistered_thread = !hl_get_thread();
+	if( on_unregistered_thread ) {
+		vdynamic *ctx;
 		hl_register_thread(&ctx);
 	}
 
-    vclosure* vcallback = (vclosure*)userdata;
+	vclosure **closure_store = userdata;
+	vclosure *vcallback = *closure_store;
 
 	int count = 0;
 
 	varray *array;
-	if( filelist )
-	{
+	if( filelist ) {
 		const char * const *p = filelist;
 		while(*p++)
 			count++;
@@ -1187,16 +1186,15 @@ void FileDialogCallback(void *userdata, const char* const *filelist, int filter)
 			memcpy(bytes, filelist[i], len);
 			data[i] = bytes;
 		}
-	}
-	else 
-	{
+	} else {
 		array = hl_alloc_array(&hlt_bytes, 0 );
 	}
 
 	hl_call1( void, vcallback, varray*, array );
-	hl_remove_root( &vcallback );
+	hl_remove_root( closure_store );
+	free( closure_store );
 
-	if( on_thread )
+	if( on_unregistered_thread )
 		hl_unregister_thread();
 }
 
@@ -1218,35 +1216,38 @@ SDL_DialogFileFilter* CreateFileDialogFilters( varray *filters ) {
 }
 
 HL_PRIM void HL_NAME(show_open_file_dialog)( vclosure *callback, SDL_Window *window, varray *filters, vstring *default_location, bool allow_many ) {
-
-	hl_add_root( &callback );
-
-	const char *clocation = default_location ? hl_to_utf8(default_location->bytes) : NULL;
+	vclosure **closure_store = malloc(sizeof(vclosure*));
+	*closure_store = callback;
+	const char *location = default_location ? hl_to_utf8(default_location->bytes) : NULL;
+	
+	hl_add_root(closure_store);
 	
 	SDL_DialogFileFilter *sdlfilters = CreateFileDialogFilters( filters );
-	SDL_ShowOpenFileDialog( FileDialogCallback, callback, window, sdlfilters, filters ? filters->size : 0, clocation, allow_many );
+	SDL_ShowOpenFileDialog( FileDialogCallback, closure_store, window, sdlfilters, filters ? filters->size : 0, location, allow_many );
 
 	free( sdlfilters );
 }
 
 HL_PRIM void HL_NAME(show_open_folder_dialog)( vclosure *callback, SDL_Window *window, vstring *default_location, bool allow_many ) {
-
-	hl_add_root( &callback );
-
-	const char *clocation = default_location ? hl_to_utf8(default_location->bytes) : NULL;
+	vclosure **closure_store = malloc(sizeof(vclosure*));
+	*closure_store = callback;
+	const char *location = default_location ? hl_to_utf8(default_location->bytes) : NULL;
 	
-	SDL_ShowOpenFolderDialog( FileDialogCallback, callback, window, clocation, allow_many );
+	hl_add_root(closure_store);
+	
+	SDL_ShowOpenFolderDialog( FileDialogCallback, closure_store, window, location, allow_many );
 
 }
 
 HL_PRIM void HL_NAME(show_save_file_dialog)( vclosure *callback, SDL_Window *window, varray *filters, vstring *default_location ) {
-	
-	hl_add_root( &callback );
+	vclosure **closure_store = malloc(sizeof(vclosure*));
+	*closure_store = callback;
+	const char *location = default_location ? hl_to_utf8(default_location->bytes) : NULL;
 
-	const char *clocation = default_location ? hl_to_utf8(default_location->bytes) : NULL;
+	hl_add_root(closure_store);
 
 	SDL_DialogFileFilter *sdlfilters = CreateFileDialogFilters( filters );
-	SDL_ShowSaveFileDialog( FileDialogCallback, callback, window, sdlfilters, filters ? filters->size : 0, clocation );
+	SDL_ShowSaveFileDialog( FileDialogCallback, closure_store, window, sdlfilters, filters ? filters->size : 0, location );
 
 	free( sdlfilters );
 }

--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -1159,25 +1159,27 @@ DEFINE_PRIM(_BYTES, get_error, _NO_ARG);
 
 // SDL Dialogs API
 typedef struct {
-	vclosure **closure_store;
+	vclosure *closure;
 	SDL_DialogFileFilter* filters;
+	int filters_size;
 } dialog_data;
 
 dialog_data* CreateFileDialogData( vclosure *callback, varray *filters ) {
 	dialog_data *data = malloc( sizeof( dialog_data ) );
-	data->closure_store = malloc(sizeof(vclosure*));
-	*data->closure_store = callback;
+	data->closure = callback;
 
-	if( filters && filters->size > 0 ) {
+	data->filters_size = filters ? filters->size : 0;
+
+	if( data->filters_size > 0 ) {
 		SDL_DialogFileFilter *sdl_filters = (SDL_DialogFileFilter *)malloc(sizeof( SDL_DialogFileFilter ) * filters->size );
 
-		for(int i=0;i<filters->size;i++) {
+		for(int i=0;i<data->filters_size;i++) {
 			vdynamic *filter = hl_aptr(filters, vdynamic*)[i];
 			const char *name = (const char*) hl_dyn_getp(filter,hl_hash_utf8("name"),&hlt_bytes);
 			const char *pattern = (const char*) hl_dyn_getp(filter,hl_hash_utf8("pattern"),&hlt_bytes);
-			
-			sdl_filters[i].name = name;
-			sdl_filters[i].pattern = pattern;
+
+			sdl_filters[i].name = strdup(name);
+			sdl_filters[i].pattern = strdup(pattern);
 		}
 
 		data->filters = sdl_filters;
@@ -1185,7 +1187,7 @@ dialog_data* CreateFileDialogData( vclosure *callback, varray *filters ) {
 	else 
 		data->filters = NULL;
 
-	hl_add_root(data->closure_store);
+	hl_add_root(&data->closure);
 
 	return data;
 }
@@ -1199,8 +1201,6 @@ void FileDialogCallback(void *userdata, const char* const *filelist, int filter)
 	}
 
 	dialog_data *data = (dialog_data*)userdata;
-	vclosure *vcallback = *data->closure_store;
-
 	int count = 0;
 
 	varray *array;
@@ -1222,9 +1222,14 @@ void FileDialogCallback(void *userdata, const char* const *filelist, int filter)
 		array = hl_alloc_array(&hlt_bytes, 0 );
 	}
 
-	hl_call1( void, vcallback, varray*, array );
-	hl_remove_root( data->closure_store );
-	free( data->closure_store );
+	hl_call1( void, data->closure, varray*, array );
+	hl_remove_root( &data->closure );
+
+	for( int i=0; i<data->filters_size; i++) {
+		free( data->filters[i].name );
+		free( data->filters[i].pattern );
+	}
+
 	free( data->filters );
 	free( data );
 

--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -1156,3 +1156,101 @@ DEFINE_PRIM(_ARR, get_display_modes, _I32);
 DEFINE_PRIM(_DYN, get_current_display_mode, _I32 _BOOL);
 DEFINE_PRIM(_ARR, get_devices, _NO_ARG);
 DEFINE_PRIM(_BYTES, get_error, _NO_ARG);
+
+// SDL Dialogs API
+void FileDialogCallback(void *userdata, const char* const *filelist, int filter) {
+	// these callbacks may come via threads on some platforms
+	bool on_thread = !hl_get_thread();
+	if( on_thread )
+	{
+		vdynamic* ctx;
+		hl_register_thread(&ctx);
+	}
+
+    vclosure* vcallback = (vclosure*)userdata;
+
+	int count = 0;
+
+	varray *array;
+	if( filelist )
+	{
+		const char * const *p = filelist;
+		while(*p++)
+			count++;
+
+		array = hl_alloc_array(&hlt_bytes, count );
+		vbyte **data = (vbyte **)hl_aptr(array, vbyte*);
+
+		for(int i = 0; i < count; i++) {
+			size_t len = strlen(filelist[i]) + 1; // Include the null terminator
+			vbyte *bytes = hl_alloc_bytes( len );
+			memcpy(bytes, filelist[i], len);
+			data[i] = bytes;
+		}
+	}
+	else 
+	{
+		array = hl_alloc_array(&hlt_bytes, 0 );
+	}
+
+	hl_call1( void, vcallback, varray*, array );
+	hl_remove_root( &vcallback );
+
+	if( on_thread )
+		hl_unregister_thread();
+}
+
+SDL_DialogFileFilter* CreateFileDialogFilters( varray *filters ) {
+	if( !filters || filters->size == 0 )
+		return NULL;
+
+	SDL_DialogFileFilter *result = (SDL_DialogFileFilter *)malloc(sizeof( SDL_DialogFileFilter ) * filters->size );
+
+	for(int i=0;i<filters->size;i++) {
+		vdynamic *filter = hl_aptr(filters, vdynamic*)[i];
+		const char *name = (const char*) hl_dyn_getp(filter,hl_hash_utf8("name"),&hlt_bytes);
+		const char *pattern = (const char*) hl_dyn_getp(filter,hl_hash_utf8("pattern"),&hlt_bytes);
+		
+		result[i].name = name;
+		result[i].pattern = pattern;
+	}
+	return result;
+}
+
+HL_PRIM void HL_NAME(show_open_file_dialog)( vclosure *callback, SDL_Window *window, varray *filters, vstring *default_location, bool allow_many ) {
+
+	hl_add_root( &callback );
+
+	const char *clocation = default_location ? hl_to_utf8(default_location->bytes) : NULL;
+	
+	SDL_DialogFileFilter *sdlfilters = CreateFileDialogFilters( filters );
+	SDL_ShowOpenFileDialog( FileDialogCallback, callback, window, sdlfilters, filters ? filters->size : 0, clocation, allow_many );
+
+	free( sdlfilters );
+}
+
+HL_PRIM void HL_NAME(show_open_folder_dialog)( vclosure *callback, SDL_Window *window, vstring *default_location, bool allow_many ) {
+
+	hl_add_root( &callback );
+
+	const char *clocation = default_location ? hl_to_utf8(default_location->bytes) : NULL;
+	
+	SDL_ShowOpenFolderDialog( FileDialogCallback, callback, window, clocation, allow_many );
+
+}
+
+HL_PRIM void HL_NAME(show_save_file_dialog)( vclosure *callback, SDL_Window *window, varray *filters, vstring *default_location ) {
+	
+	hl_add_root( &callback );
+
+	const char *clocation = default_location ? hl_to_utf8(default_location->bytes) : NULL;
+
+	SDL_DialogFileFilter *sdlfilters = CreateFileDialogFilters( filters );
+	SDL_ShowSaveFileDialog( FileDialogCallback, callback, window, sdlfilters, filters ? filters->size : 0, clocation );
+
+	free( sdlfilters );
+}
+
+DEFINE_PRIM(_VOID, show_open_file_dialog, _FUN(_VOID, _ARR) TWIN _ARR _STRING _BOOL );
+DEFINE_PRIM(_VOID, show_open_folder_dialog, _FUN(_VOID, _ARR) TWIN _STRING _BOOL );
+DEFINE_PRIM(_VOID, show_save_file_dialog, _FUN(_VOID, _ARR) TWIN _ARR _STRING );

--- a/libs/sdl/sdl.c
+++ b/libs/sdl/sdl.c
@@ -1158,6 +1158,40 @@ DEFINE_PRIM(_ARR, get_devices, _NO_ARG);
 DEFINE_PRIM(_BYTES, get_error, _NO_ARG);
 
 // SDL Dialogs API
+typedef struct {
+	vclosure **closure_store;
+	SDL_DialogFileFilter* filters;
+} dialog_data;
+
+dialog_data* CreateFileDialogData( vclosure *callback, varray *filters )
+{
+	dialog_data *data = malloc( sizeof( dialog_data ) );
+	data->closure_store = malloc(sizeof(vclosure*));
+	*data->closure_store = callback;
+
+	if( filters && filters->size > 0 )
+	{
+		SDL_DialogFileFilter *sdl_filters = (SDL_DialogFileFilter *)malloc(sizeof( SDL_DialogFileFilter ) * filters->size );
+
+		for(int i=0;i<filters->size;i++) {
+			vdynamic *filter = hl_aptr(filters, vdynamic*)[i];
+			const char *name = (const char*) hl_dyn_getp(filter,hl_hash_utf8("name"),&hlt_bytes);
+			const char *pattern = (const char*) hl_dyn_getp(filter,hl_hash_utf8("pattern"),&hlt_bytes);
+			
+			sdl_filters[i].name = name;
+			sdl_filters[i].pattern = pattern;
+		}
+
+		data->filters = sdl_filters;
+	}
+	else 
+		data->filters = NULL;
+
+	hl_add_root(data->closure_store);
+
+	return data;
+}
+
 void FileDialogCallback(void *userdata, const char* const *filelist, int filter) {
 	// these callbacks may come via threads on some platforms
 	bool on_unregistered_thread = !hl_get_thread();
@@ -1166,8 +1200,8 @@ void FileDialogCallback(void *userdata, const char* const *filelist, int filter)
 		hl_register_thread(&ctx);
 	}
 
-	vclosure **closure_store = userdata;
-	vclosure *vcallback = *closure_store;
+	dialog_data *data = (dialog_data*)userdata;
+	vclosure *vcallback = *data->closure_store;
 
 	int count = 0;
 
@@ -1178,78 +1212,50 @@ void FileDialogCallback(void *userdata, const char* const *filelist, int filter)
 			count++;
 
 		array = hl_alloc_array(&hlt_bytes, count );
-		vbyte **data = (vbyte **)hl_aptr(array, vbyte*);
+		vbyte **array_ptr = (vbyte **)hl_aptr(array, vbyte*);
 
 		for(int i = 0; i < count; i++) {
 			size_t len = strlen(filelist[i]) + 1; // Include the null terminator
 			vbyte *bytes = hl_alloc_bytes( len );
 			memcpy(bytes, filelist[i], len);
-			data[i] = bytes;
+			array_ptr[i] = bytes;
 		}
 	} else {
 		array = hl_alloc_array(&hlt_bytes, 0 );
 	}
 
 	hl_call1( void, vcallback, varray*, array );
-	hl_remove_root( closure_store );
-	free( closure_store );
+	hl_remove_root( data->closure_store );
+	free( data->closure_store );
+	free( data->filters );
+	free( data );
 
 	if( on_unregistered_thread )
 		hl_unregister_thread();
 }
 
-SDL_DialogFileFilter* CreateFileDialogFilters( varray *filters ) {
-	if( !filters || filters->size == 0 )
-		return NULL;
-
-	SDL_DialogFileFilter *result = (SDL_DialogFileFilter *)malloc(sizeof( SDL_DialogFileFilter ) * filters->size );
-
-	for(int i=0;i<filters->size;i++) {
-		vdynamic *filter = hl_aptr(filters, vdynamic*)[i];
-		const char *name = (const char*) hl_dyn_getp(filter,hl_hash_utf8("name"),&hlt_bytes);
-		const char *pattern = (const char*) hl_dyn_getp(filter,hl_hash_utf8("pattern"),&hlt_bytes);
-		
-		result[i].name = name;
-		result[i].pattern = pattern;
-	}
-	return result;
-}
-
 HL_PRIM void HL_NAME(show_open_file_dialog)( vclosure *callback, SDL_Window *window, varray *filters, vstring *default_location, bool allow_many ) {
-	vclosure **closure_store = malloc(sizeof(vclosure*));
-	*closure_store = callback;
 	const char *location = default_location ? hl_to_utf8(default_location->bytes) : NULL;
 	
-	hl_add_root(closure_store);
+	dialog_data *data = CreateFileDialogData( callback, filters );
 	
-	SDL_DialogFileFilter *sdlfilters = CreateFileDialogFilters( filters );
-	SDL_ShowOpenFileDialog( FileDialogCallback, closure_store, window, sdlfilters, filters ? filters->size : 0, location, allow_many );
-
-	free( sdlfilters );
+	SDL_ShowOpenFileDialog( FileDialogCallback, data, window, data->filters, filters ? filters->size : 0, location, allow_many );
 }
 
 HL_PRIM void HL_NAME(show_open_folder_dialog)( vclosure *callback, SDL_Window *window, vstring *default_location, bool allow_many ) {
-	vclosure **closure_store = malloc(sizeof(vclosure*));
-	*closure_store = callback;
 	const char *location = default_location ? hl_to_utf8(default_location->bytes) : NULL;
 	
-	hl_add_root(closure_store);
+	dialog_data *data = CreateFileDialogData( callback, NULL );
 	
-	SDL_ShowOpenFolderDialog( FileDialogCallback, closure_store, window, location, allow_many );
-
+	SDL_ShowOpenFolderDialog( FileDialogCallback, data, window, location, allow_many );
 }
 
 HL_PRIM void HL_NAME(show_save_file_dialog)( vclosure *callback, SDL_Window *window, varray *filters, vstring *default_location ) {
-	vclosure **closure_store = malloc(sizeof(vclosure*));
-	*closure_store = callback;
 	const char *location = default_location ? hl_to_utf8(default_location->bytes) : NULL;
+	
+	dialog_data *data = CreateFileDialogData( callback, filters );
 
-	hl_add_root(closure_store);
-
-	SDL_DialogFileFilter *sdlfilters = CreateFileDialogFilters( filters );
-	SDL_ShowSaveFileDialog( FileDialogCallback, closure_store, window, sdlfilters, filters ? filters->size : 0, location );
-
-	free( sdlfilters );
+	SDL_ShowSaveFileDialog( FileDialogCallback, data, window, data->filters, filters ? filters->size : 0, location );
 }
 
 DEFINE_PRIM(_VOID, show_open_file_dialog, _FUN(_VOID, _ARR) TWIN _ARR _STRING _BOOL );

--- a/libs/sdl/sdl/Sdl.hx
+++ b/libs/sdl/sdl/Sdl.hx
@@ -307,6 +307,9 @@ class Sdl {
 
 	public static function showOpenFileDialog(callback: FileDialogCallback, window: sdl.Window = null, filters: Array<DialogFileFilter> = null, defaultLocation: String = null, allowMultiple: Bool = false) {
 		var cb = ( bytes: hl.NativeArray<hl.Bytes>) -> {
+			if( bytes == null )
+				throw getError();
+			
 			var files = [];
 			for( b in bytes )
 				files.push( @:privateAccess String.fromUTF8( b ) );
@@ -321,6 +324,9 @@ class Sdl {
 
 	public static function showOpenFolderDialog(callback: FileDialogCallback, window: sdl.Window = null, defaultLocation: String = null, allowMultiple: Bool = false) {
 		var cb = ( bytes: hl.NativeArray<hl.Bytes>) -> {
+			if( bytes == null )
+				throw getError();
+
 			var files = [];
 			for( b in bytes )
 				files.push( @:privateAccess String.fromUTF8( b ) );
@@ -333,6 +339,9 @@ class Sdl {
 
 	public static function showSaveFileDialog(callback: FileDialogCallback, window: sdl.Window = null, filters: Array<DialogFileFilter> = null, defaultLocation: String = null) {
 		var cb = ( bytes: hl.NativeArray<hl.Bytes>) -> {
+			if( bytes == null )
+				throw getError();
+
 			var files = [];
 			for( b in bytes )
 				files.push( @:privateAccess String.fromUTF8( b ) );

--- a/libs/sdl/sdl/Sdl.hx
+++ b/libs/sdl/sdl/Sdl.hx
@@ -288,7 +288,7 @@ class Sdl {
 	// SDL3 Dialogs API
 	//
 
-	static function processFilters(filters: Array<DialogFileFilter> = null)
+	private static function processFilters(filters: Array<DialogFileFilter> = null)
 	{
 		var nativeFilters = null;
 		if( filters != null )
@@ -346,7 +346,6 @@ class Sdl {
 
 		var nativeFilters = processFilters( filters );
 
-
 		_showSaveFileDialog( cb, window != null ? @:privateAccess window.win : null, nativeFilters, defaultLocation);
 	}
 
@@ -355,12 +354,12 @@ class Sdl {
 	private static function _showOpenFileDialog(callback: (bytes: hl.NativeArray<hl.Bytes>) -> Void, window: sdl.Window.WinPtr, filters: hl.NativeArray<Dynamic>, defaultLocation: String, allowMultiple: Bool) : Void {
 	}
 
-	@:hlNative("?sdl", "show_save_file_dialog")
-	private static function _showSaveFileDialog(callback: (bytes: hl.NativeArray<hl.Bytes>) -> Void, window: sdl.Window.WinPtr, filters: hl.NativeArray<Dynamic>, defaultLocation: String) : Void {
-	}
-
 	@:hlNative("?sdl", "show_open_folder_dialog")
 	private static function _showOpenFolderDialog(callback: (bytes: hl.NativeArray<hl.Bytes>) -> Void, window: sdl.Window.WinPtr,  defaultLocation: String, allowMultiple: Bool) : Void {
+	}
+
+	@:hlNative("?sdl", "show_save_file_dialog")
+	private static function _showSaveFileDialog(callback: (bytes: hl.NativeArray<hl.Bytes>) -> Void, window: sdl.Window.WinPtr, filters: hl.NativeArray<Dynamic>, defaultLocation: String) : Void {
 	}
 }
 

--- a/libs/sdl/sdl/Sdl.hx
+++ b/libs/sdl/sdl/Sdl.hx
@@ -288,16 +288,12 @@ class Sdl {
 	// SDL3 Dialogs API
 	//
 
-	private static function processFilters(filters: Array<DialogFileFilter> = null)
-	{
+	private static function processFilters(filters: Array<DialogFileFilter> = null) {
 		var nativeFilters = null;
-		if( filters != null )
-		{
+		if( filters != null ) {
 			nativeFilters = new hl.NativeArray<Dynamic>( filters.length );
-			for( i in 0 ... filters.length )
-			{
-				@:privateAccess
-				{
+			for( i in 0 ... filters.length ) {
+				@:privateAccess {
 					nativeFilters[i] = {
 						"name": filters[i].name.toUtf8(),
 						"pattern": filters[i].pattern.toUtf8(),

--- a/libs/sdl/sdl/Sdl.hx
+++ b/libs/sdl/sdl/Sdl.hx
@@ -16,6 +16,12 @@ typedef ScreenMode = {
 	var framerate : Int;
 };
 
+typedef FileDialogCallback = ( Array<String> ) -> Void;
+typedef DialogFileFilter = {
+	public var name: String;
+	public var pattern: String;
+}
+
 @:hlNative("sdl")
 class Sdl {
 
@@ -276,6 +282,85 @@ class Sdl {
 	@:hlNative("?sdl", "get_joysticks")
 	private static function _getJoysticks() : hl.NativeArray<Int> {
 		return null;
+	}
+
+	//
+	// SDL3 Dialogs API
+	//
+
+	static function processFilters(filters: Array<DialogFileFilter> = null)
+	{
+		var nativeFilters = null;
+		if( filters != null )
+		{
+			nativeFilters = new hl.NativeArray<Dynamic>( filters.length );
+			for( i in 0 ... filters.length )
+			{
+				@:privateAccess
+				{
+					nativeFilters[i] = {
+						"name": filters[i].name.toUtf8(),
+						"pattern": filters[i].pattern.toUtf8(),
+					};
+				}
+			}
+		}
+		return nativeFilters;
+
+	}
+
+	public static function showOpenFileDialog(callback: FileDialogCallback, window: sdl.Window = null, filters: Array<DialogFileFilter> = null, defaultLocation: String = null, allowMultiple: Bool = false) {
+		var cb = ( bytes: hl.NativeArray<hl.Bytes>) -> {
+			var files = [];
+			for( b in bytes )
+				files.push( @:privateAccess String.fromUTF8( b ) );
+
+			callback(files);
+		};
+
+		var nativeFilters = processFilters( filters );
+
+		_showOpenFileDialog( cb, window != null ? @:privateAccess window.win : null, nativeFilters, defaultLocation, allowMultiple);
+	}
+
+	public static function showOpenFolderDialog(callback: FileDialogCallback, window: sdl.Window = null, defaultLocation: String = null, allowMultiple: Bool = false) {
+		var cb = ( bytes: hl.NativeArray<hl.Bytes>) -> {
+			var files = [];
+			for( b in bytes )
+				files.push( @:privateAccess String.fromUTF8( b ) );
+
+			callback(files);
+		};
+
+		_showOpenFolderDialog( cb, window != null ? @:privateAccess window.win : null, defaultLocation, allowMultiple);
+	}
+
+	public static function showSaveFileDialog(callback: FileDialogCallback, window: sdl.Window = null, filters: Array<DialogFileFilter> = null, defaultLocation: String = null) {
+		var cb = ( bytes: hl.NativeArray<hl.Bytes>) -> {
+			var files = [];
+			for( b in bytes )
+				files.push( @:privateAccess String.fromUTF8( b ) );
+
+			callback(files);
+		};
+
+		var nativeFilters = processFilters( filters );
+
+
+		_showSaveFileDialog( cb, window != null ? @:privateAccess window.win : null, nativeFilters, defaultLocation);
+	}
+
+
+	@:hlNative("?sdl", "show_open_file_dialog")
+	private static function _showOpenFileDialog(callback: (bytes: hl.NativeArray<hl.Bytes>) -> Void, window: sdl.Window.WinPtr, filters: hl.NativeArray<Dynamic>, defaultLocation: String, allowMultiple: Bool) : Void {
+	}
+
+	@:hlNative("?sdl", "show_save_file_dialog")
+	private static function _showSaveFileDialog(callback: (bytes: hl.NativeArray<hl.Bytes>) -> Void, window: sdl.Window.WinPtr, filters: hl.NativeArray<Dynamic>, defaultLocation: String) : Void {
+	}
+
+	@:hlNative("?sdl", "show_open_folder_dialog")
+	private static function _showOpenFolderDialog(callback: (bytes: hl.NativeArray<hl.Bytes>) -> Void, window: sdl.Window.WinPtr,  defaultLocation: String, allowMultiple: Bool) : Void {
 	}
 }
 


### PR DESCRIPTION
This PR adds support for File/Folder open/save dialogs via SDL3. These are platform agnostic async calls that should function consistently across all supported targets, and use modern APIs that should match the user's OS.

The implementation here is a bit icky in a few spots as we need to jump through some hoops to get strings in and out of HL. I chose to hide as much of this complexity in sdl.hx as possible, but arguments can be made for shifting it up or down the call tree. I don't think it matters much where this code lives as long as it's not user facing, so the important bit is the sdl.hx interface which exposes `FileDialogCallback` and `DialogFileFilter`.

Some notes:
- SDL will always trigger the callback, even if the user cancels or the function fails due to other reasons (eg, bad filter data, etc). With this contract it's safe to leave cleanup to `FileDialogCallback` in sdl.c and not worry about leaking memory or gc roots.
- Zeta assisted on the gc root code, but it's worth getting a second set of eyes on the implementation since I blindly ran with his suggestion; I don't fully understand the entire memory ownership model of the gc and it may not make sense the way I implemented it. It appears to work in my testing.
- I really wish we could pass strings through HL without the intermediate hl.bytes stage, but I couldn't find a way to do this.

### Use cases
- Currently, my in-house tools for heaps heavily lean on an older version of this code for save/load/selection on linux.
- Hide likely also needs this if we ever want it to work reasonably well outside of windows.

### Why not use UI.hdll?
Currently there are no other options for file dialogs in HL outside of windows. `ui.hdll` has some vague hints towards being portable but there's no work currently done on other platforms, and maintaining versions across all platforms is a non-trivial endeavor, especially on linux where there are a large number of windowing systems with subtly different APIs. SDL3 has already done this work for us, and is likely in use for window creation on non-windows platforms anyway.