### PR TITLE
Win: Add no console by default and attach later

### DIFF
--- a/hl.vcxproj
+++ b/hl.vcxproj
@@ -204,7 +204,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
       <AdditionalOptions>/wd4456 /wd4100 /wd4204 /wd4702 /wd4457 %(AdditionalOptions)</AdditionalOptions>
       <BufferSecurityCheck>false</BufferSecurityCheck>
@@ -216,7 +216,7 @@
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
+      <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
@@ -264,7 +264,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;HL_VTUNE;HL_DX12_AGILITY_VERSION=618;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;HL_VTUNE;HL_DX12_AGILITY_VERSION=618;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/wd4456 /wd4100 /wd4204 /wd4702 /wd4457 %(AdditionalOptions)</AdditionalOptions>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <ConformanceMode>true</ConformanceMode>
@@ -275,7 +275,7 @@
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
+      <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>

--- a/libs/ui/ui_stub.c
+++ b/libs/ui/ui_stub.c
@@ -58,6 +58,14 @@ HL_PRIM bool HL_NAME(ui_sentinel_is_paused)( vsentinel *s ) {
 	return false;
 }
 
+HL_PRIM bool HL_NAME(ui_create_console)() {
+	return false;
+}
+
+HL_PRIM bool HL_NAME(ui_attach_console)( int pid ) {
+	return false;
+}
+
 HL_PRIM void HL_NAME(ui_close_console)() {
 }
 
@@ -86,6 +94,8 @@ DEFINE_PRIM(_VOID, ui_win_set_enable, _WIN _BOOL);
 DEFINE_PRIM(_VOID, ui_win_destroy, _WIN);
 DEFINE_PRIM(_I32, ui_loop, _BOOL);
 DEFINE_PRIM(_VOID, ui_stop_loop, _NO_ARG);
+DEFINE_PRIM(_BOOL, ui_create_console, _NO_ARG);
+DEFINE_PRIM(_BOOL, ui_attach_console, _I32);
 DEFINE_PRIM(_VOID, ui_close_console, _NO_ARG);
 
 DEFINE_PRIM(_SENTINEL, ui_start_sentinel, _F64 _FUN(_VOID,_NO_ARG));

--- a/libs/ui/ui_win.c
+++ b/libs/ui/ui_win.c
@@ -228,7 +228,7 @@ static void sentinel_loop( vsentinel *s ) {
 				// simulate a call
 #				ifdef HL_64
 				int_val* rsp = (int_val*)regs.Rsp;
-				// ensure the stack is aligned to 16 bytes 
+				// ensure the stack is aligned to 16 bytes
 				rsp = (int_val*)((int_val)rsp & ~15);
 				*--rsp = (int_val)regs.Rip;
 				regs.Rsp = (int_val)rsp;
@@ -276,6 +276,26 @@ HL_PRIM void HL_NAME(ui_sentinel_pause)( vsentinel *s, bool pause ) {
 
 HL_PRIM bool HL_NAME(ui_sentinel_is_paused)( vsentinel *s ) {
 	return s->pause;
+}
+
+static void reattach_std() {
+	freopen("CONIN$","r",stdin);
+	freopen("CONOUT$","w",stdout);
+	freopen("CONOUT$","w",stderr);
+}
+
+HL_PRIM bool HL_NAME(ui_create_console)() {
+	if( !AllocConsole() )
+		return false;
+	reattach_std();
+	return true;
+}
+
+HL_PRIM bool HL_NAME(ui_attach_console)( int pid ) {
+	if( !AttachConsole(pid) )
+		return false;
+	reattach_std();
+	return true;
 }
 
 HL_PRIM void HL_NAME(ui_close_console)() {
@@ -390,6 +410,8 @@ DEFINE_PRIM(_VOID, ui_win_set_enable, _WIN _BOOL);
 DEFINE_PRIM(_VOID, ui_win_destroy, _WIN);
 DEFINE_PRIM(_I32, ui_loop, _BOOL);
 DEFINE_PRIM(_VOID, ui_stop_loop, _NO_ARG);
+DEFINE_PRIM(_BOOL, ui_create_console, _NO_ARG);
+DEFINE_PRIM(_BOOL, ui_attach_console, _I32);
 DEFINE_PRIM(_VOID, ui_close_console, _NO_ARG);
 
 DEFINE_PRIM(_SENTINEL, ui_start_sentinel, _F64 _FUN(_VOID,_NO_ARG));

--- a/src/main.c
+++ b/src/main.c
@@ -325,7 +325,7 @@ int main(int argc, pchar *argv[]) {
 	return 0;
 }
 
-#ifdef HL_WIN
+#if (defined(HL_WIN_DESKTOP) && !defined(_CONSOLE)) || defined(HL_XBS)
 int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR lpCmdLine, int nCmdShow) {
 	return wmain(__argc, __wargv);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -325,3 +325,8 @@ int main(int argc, pchar *argv[]) {
 	return 0;
 }
 
+#ifdef HL_WIN
+int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR lpCmdLine, int nCmdShow) {
+	return wmain(__argc, __wargv);
+}
+#endif


### PR DESCRIPTION
It seems that sometimes for a game release, we don't want the cmd window pop-up. This PR:
- Added `wWinMain` in main.c so one can compile with `subsystem:windows`
- Added `ui_create_console`, `ui_attach_console` to enable the console when we need it (API in haxe)
- Activated for the configuration `ReleaseDX12Agility`

The downside (?) is that the console window will look like a normal window instead of a cmd window.

Haxe side API:

```haxe
	#if (hl_ver >= version("1.16.0"))
	@:hlNative("?ui", "ui_create_console")
	public static function createConsole():Bool {
		return false;
	}

	@:hlNative("?ui", "ui_attach_console")
	public static function attachConsole(pid:Int):Bool {
		return false;
	}
	#end

```

For a better experience with debugger I think the expected usage is :

```haxe
if( !hl.Api.hasDebugger() ) {
	hl.UI.createConsole();
}
```