### PR TITLE
DX12Aftermath: simplify sdk location and minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 *.n
 Debug
 Release
+ReleaseAftermath
+ReleaseDX12Agility
 x64
 *.stackdump
 *.hdll
@@ -25,6 +27,7 @@ x64
 /hl
 /include/sdl
 /include/openal
+/include/aftermath
 ReleaseStatic
 /other/benchs/bench.*
 /other/benchs/cpp

--- a/libs/directx/README.md
+++ b/libs/directx/README.md
@@ -2,7 +2,7 @@
 
 ## DirectX 12 Agility SDK
 
-To build and run the project with the DirectX 12 Agility SDK, ensure that the required Agility SDK package version matches the value of HL_DX12_AGILITY_VERSION.
+To build and run the project with the DirectX 12 Agility SDK, ensure that the required Agility SDK package version matches the value of `HL_DX12_AGILITY_VERSION`.
 
 These files must be placed in a D3D12 directory located next to the application executable:
 
@@ -17,19 +17,9 @@ If the versions do not match, the DirectX 12 debug/SDK layers may fail to load o
 
 ## Nsight  Aftermath (Enabled by Default with Agility SDK)
 
-The default Agility SDK configuration enables **Nsight  Aftermath** for GPU crash diagnostics.
+The default Agility SDK configuration enables **Nsight  Aftermath** for GPU crash diagnostics (`HL_AFTERMATH`).
 
-To build with this configuration, the Nsight  Aftermath SDK must be available in the following locations relative to the HashLink repository:
-
-- Header files:
-  ```
-  <hashlink>/include/aftermath/
-  ```
-- Library files:
-  ```
-  <hashlink>/include/aftermath/x64
-  <hashlink>/include/aftermath/x86
-  ```
+To build with this configuration, the [Nsight Aftermath SDK](https://developer.nvidia.com/nsight-aftermath) (tested with 2026.3 - Version API 2.27) must be extracted to `<hashlink>/include/aftermath/`.
 
 In addition, the required Nsight Aftermath DLLs must be placed next to the application executable so they can be loaded at runtime.
 

--- a/libs/directx/dx12.vcxproj
+++ b/libs/directx/dx12.vcxproj
@@ -103,43 +103,43 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
     <TargetExt>.hdll</TargetExt>
-    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86;../../$(Configuration);../../include/aftermath/x86</LibraryPath>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);../../src;../../include/aftermath</IncludePath>
+    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86;../../$(Configuration)</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);../../src</IncludePath>
     <IntDir>$(Configuration)\dx12\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
     <TargetExt>.hdll</TargetExt>
-    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;../../x64/$(Configuration);../../include/aftermath/x64</LibraryPath>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);../../src;../../include/aftermath</IncludePath>
+    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;../../x64/$(Configuration)</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);../../src</IncludePath>
     <IntDir>$(Platform)\$(Configuration)\dx12\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <TargetExt>.hdll</TargetExt>
-    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86;../../$(Configuration);../../include/aftermath/x86</LibraryPath>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);../../src;../../include/aftermath</IncludePath>
+    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86;../../$(Configuration)</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);../../src</IncludePath>
     <IntDir>$(Configuration)\dx12\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseAftermath|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <TargetExt>.hdll</TargetExt>
-    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86;../../$(Configuration);../../Release;../../include/aftermath/x86</LibraryPath>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);../../src;../../include/aftermath</IncludePath>
+    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86;../../$(Configuration);../../Release;../../include/aftermath/lib/x86</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);../../src;../../include/aftermath/include</IncludePath>
     <IntDir>$(Configuration)\dx12\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <TargetExt>.hdll</TargetExt>
-    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;../../x64/$(Configuration);../../include/aftermath/x64</LibraryPath>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);../../src;../../include/aftermath</IncludePath>
+    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;../../x64/$(Configuration)</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);../../src</IncludePath>
     <IntDir>$(Platform)\$(Configuration)\dx12\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseAftermath|x64'">
     <LinkIncremental>false</LinkIncremental>
     <TargetExt>.hdll</TargetExt>
-    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;../../x64/$(Configuration);../../x64/Release;../../include/aftermath/x64</LibraryPath>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);../../src;../../include/aftermath</IncludePath>
+    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;../../x64/$(Configuration);../../x64/Release;../../include/aftermath/lib/x64</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);../../src;../../include/aftermath/include</IncludePath>
     <IntDir>$(Platform)\$(Configuration)\dx12\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -254,7 +254,6 @@
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>
       </PrecompiledHeader>
-      <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;DIRECTX_EXPORTS;%(PreprocessorDefinitions);HL_AFTERMATH</PreprocessorDefinitions>


### PR DESCRIPTION
- git ignore sdk folder
- simplify sdk location (unzip to `include/aftermath` is enough)
- add supported sdk version info
- remove useless include in configuration that does not use aftermath
- fix optimisation level