### PR TITLE
Remove Streamline Interposer

### DIFF
--- a/libs/directx/README.md
+++ b/libs/directx/README.md
@@ -30,19 +30,3 @@ When building the **HashLink** `ReleaseDX12Agility` configuration, Aftermath can
 This excludes Nsight Aftermath from the build and removes the dependency on the Aftermath SDK and runtime DLLs.
 
 You can also manually remove the preprocessor (`HL_AFTERMATH`) from the **ReleaseAll** configuration if you want to use the others optional features.
-
-## Streamline (Enabled by Default with Agility SDK)
-
-The default Agility SDK configuration links against sl.interposer.lib to enable the DLSS implementation provided by hlheaps. (https://github.com/HeapsIO/hlheaps/).
-
-To build with this, the [Streamline SDK](https://github.com/NVIDIA-RTX/Streamline) (tested with 2026.3 - Version API 2.12.0) must be extracted to `<hashlink>/include/streamline/`. 
-
-In addition, the required Streamline DLLs must be placed next to the application executable so they can be loaded at runtime.
-
-### Building Without Streamline
-
-When building the **HashLink** `ReleaseDX12Agility` configuration, Streamline can be disabled by building the **dx12** project using the **Release** configuration instead of **ReleaseAll**.
-
-This excludes Streamline from the build and removes the dependency on the Streamline SDK and runtime DLLs.
-
-You can also manually remove the preprocessor (`HL_STREAMLINE`) from the **ReleaseAll** configuration if you want to use the others optional features.

--- a/libs/directx/dx/Dx12.hx
+++ b/libs/directx/dx/Dx12.hx
@@ -8,7 +8,7 @@ typedef Device = hl.Abstract<"dx_device">;
 
 typedef Adapter = hl.Abstract<"dx_adapter">;
 
-typedef DxRef = hl.Abstract<"dx_ref">;
+typedef Factory = hl.Abstract<"dx_factory">;
 
 enum DriverInitFlag {
 	DEBUG;
@@ -1674,16 +1674,18 @@ class Dx12 {
 		return null;
 	}
 
-	public static function getDeviceRef() : DxRef {
-		return null;
-	}
-
-	public static function getFactoryRef() : DxRef {
+	public static function getFactory() : Factory {
 		return null;
 	}
 
 	public static function getAdapter() : Adapter {
 		return null;
+	}
+
+	public static function setDevice(device : Device) {
+	}
+
+	public static function setFactory(factory : Factory) {
 	}
 
 	public static function flushMessages() {

--- a/libs/directx/dx/Dx12.hx
+++ b/libs/directx/dx/Dx12.hx
@@ -8,6 +8,8 @@ typedef Device = hl.Abstract<"dx_device">;
 
 typedef Adapter = hl.Abstract<"dx_adapter">;
 
+typedef DxRef = hl.Abstract<"dx_ref">;
+
 enum DriverInitFlag {
 	DEBUG;
 	GPU_BASED_VALIDATION;
@@ -1665,7 +1667,18 @@ class Dx12 {
 		return dxCreate(@:privateAccess win.win, flags, deviceName == null ? null : @:privateAccess deviceName.bytes);
 	}
 
+	public static function createCommandQueue() {
+	}
+
 	public static function getDevice() : Device {
+		return null;
+	}
+
+	public static function getDeviceRef() : DxRef {
+		return null;
+	}
+
+	public static function getFactoryRef() : DxRef {
 		return null;
 	}
 

--- a/libs/directx/dx12.cpp
+++ b/libs/directx/dx12.cpp
@@ -2,13 +2,6 @@
 #include <hl.h>
 #undef _GUID
 
-#ifdef HL_STREAMLINE
-#pragma comment(lib, "sl.interposer.lib")
-#else
-#pragma comment(lib, "D3D12.lib")
-#pragma comment(lib, "dxgi.lib")
-#endif
-
 #ifdef HL_WIN_DESKTOP
 #include <dxgi.h>
 #include <dxgi1_5.h>
@@ -290,12 +283,24 @@ static int CURRENT_NODEMASK = 0;
 static LARGE_INTEGER driver_version = {0};
 
 typedef ID3D12Device2 dx_device;
+typedef void* dx_ref;
 
 #define _DEVICE _ABSTRACT(dx_device)
+#define _DXREF _ABSTRACT(dx_ref)
 
 HL_PRIM ID3D12Device* HL_NAME(get_device)() {
 	dx_driver* drv = static_driver;
 	return drv->device;
+}
+
+HL_PRIM void** HL_NAME(get_device_ref)() {
+	dx_driver* drv = static_driver;
+	return (void**)&drv->device;
+}
+
+HL_PRIM void** HL_NAME(get_factory_ref)() {
+	dx_driver* drv = static_driver;
+	return (void**)&drv->factory;
 }
 
 typedef IDXGIAdapter dx_adapter;
@@ -456,17 +461,18 @@ HL_PRIM dx_driver *HL_NAME(create)( HWND window, DriverInitFlag flags, uchar *de
 	if (GpuCrashTracker::s_pfnOnGpuCrashFile)
 		drv->gpuCrashTracker = new GpuCrashTracker(drv->device);
 
-	{
-		D3D12_COMMAND_QUEUE_DESC desc = {};
-		desc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
-		desc.Priority = D3D12_COMMAND_QUEUE_PRIORITY_NORMAL;
-		desc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
-		desc.NodeMask = CURRENT_NODEMASK;
-		CHKERR(drv->device->CreateCommandQueue(&desc, IID_PPV_ARGS(&drv->commandQueue)));
-	}
-
 	static_driver = drv;
 	return drv;
+}
+
+HL_PRIM void HL_NAME(create_command_queue)() {
+	dx_driver* drv = static_driver;
+	D3D12_COMMAND_QUEUE_DESC desc = {};
+	desc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+	desc.Priority = D3D12_COMMAND_QUEUE_PRIORITY_NORMAL;
+	desc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+	desc.NodeMask = CURRENT_NODEMASK;
+	CHKERR(drv->device->CreateCommandQueue(&desc, IID_PPV_ARGS(&drv->commandQueue)));
 }
 
 #ifdef HL_XBS
@@ -654,7 +660,10 @@ HL_PRIM void HL_NAME(query_video_memory_info)( int group, void *mem ) {
 
 DEFINE_PRIM(_ARR, list_devices, _NO_ARG);
 DEFINE_PRIM(_DRIVER, create, _ABSTRACT(dx_window) _I32 _BYTES);
+DEFINE_PRIM(_VOID, create_command_queue, _NO_ARG);
 DEFINE_PRIM(_DEVICE, get_device, _NO_ARG);
+DEFINE_PRIM(_DXREF, get_device_ref, _NO_ARG);
+DEFINE_PRIM(_DXREF, get_factory_ref, _NO_ARG);
 DEFINE_PRIM(_ADAPTER, get_adapter, _NO_ARG);
 DEFINE_PRIM(_VOID, resize, _I32 _I32 _I32 _I32);
 DEFINE_PRIM(_VOID, present, _BOOL);

--- a/libs/directx/dx12.cpp
+++ b/libs/directx/dx12.cpp
@@ -283,34 +283,43 @@ static int CURRENT_NODEMASK = 0;
 static LARGE_INTEGER driver_version = {0};
 
 typedef ID3D12Device2 dx_device;
-typedef void* dx_ref;
+typedef IDXGIFactory4 dx_factory;
+typedef IDXGIAdapter dx_adapter;
 
 #define _DEVICE _ABSTRACT(dx_device)
-#define _DXREF _ABSTRACT(dx_ref)
+#define _FACTORY _ABSTRACT(dx_factory)
+#define _ADAPTER _ABSTRACT(dx_adapter)
 
 HL_PRIM ID3D12Device* HL_NAME(get_device)() {
 	dx_driver* drv = static_driver;
 	return drv->device;
 }
 
-HL_PRIM void** HL_NAME(get_device_ref)() {
+HL_PRIM IDXGIFactory4* HL_NAME(get_factory)() {
 	dx_driver* drv = static_driver;
-	return (void**)&drv->device;
+	return drv->factory;
 }
-
-HL_PRIM void** HL_NAME(get_factory_ref)() {
-	dx_driver* drv = static_driver;
-	return (void**)&drv->factory;
-}
-
-typedef IDXGIAdapter dx_adapter;
-
-#define _ADAPTER _ABSTRACT(dx_adapter)
 
 HL_PRIM IDXGIAdapter* HL_NAME(get_adapter)() {
 	dx_driver* drv = static_driver;
 	return drv->adapter;
 }
+
+HL_PRIM void HL_NAME(set_device)(ID3D12Device2* device) {
+	dx_driver* drv = static_driver;
+	drv->device = device;
+}
+
+HL_PRIM void HL_NAME(set_factory)(IDXGIFactory4* factory) {
+	dx_driver* drv = static_driver;
+	drv->factory = factory;
+}
+
+DEFINE_PRIM(_DEVICE, get_device, _NO_ARG);
+DEFINE_PRIM(_FACTORY, get_factory, _NO_ARG);
+DEFINE_PRIM(_ADAPTER, get_adapter, _NO_ARG);
+DEFINE_PRIM(_VOID, set_device, _DEVICE);
+DEFINE_PRIM(_VOID, set_factory, _FACTORY);
 
 HL_PRIM void dx12_flush_messages();
 
@@ -661,10 +670,6 @@ HL_PRIM void HL_NAME(query_video_memory_info)( int group, void *mem ) {
 DEFINE_PRIM(_ARR, list_devices, _NO_ARG);
 DEFINE_PRIM(_DRIVER, create, _ABSTRACT(dx_window) _I32 _BYTES);
 DEFINE_PRIM(_VOID, create_command_queue, _NO_ARG);
-DEFINE_PRIM(_DEVICE, get_device, _NO_ARG);
-DEFINE_PRIM(_DXREF, get_device_ref, _NO_ARG);
-DEFINE_PRIM(_DXREF, get_factory_ref, _NO_ARG);
-DEFINE_PRIM(_ADAPTER, get_adapter, _NO_ARG);
 DEFINE_PRIM(_VOID, resize, _I32 _I32 _I32 _I32);
 DEFINE_PRIM(_VOID, present, _BOOL);
 DEFINE_PRIM(_VOID, suspend, _NO_ARG);

--- a/libs/directx/dx12.vcxproj
+++ b/libs/directx/dx12.vcxproj
@@ -229,7 +229,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>libhl.lib;dxcompiler.lib</AdditionalDependencies>
+      <AdditionalDependencies>libhl.lib;dxcompiler.lib;D3D12.lib;dxgi.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugAll|x64'">
@@ -245,7 +245,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>libhl.lib;dxcompiler.lib</AdditionalDependencies>
+      <AdditionalDependencies>libhl.lib;dxcompiler.lib;D3D12.lib;dxgi.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -319,7 +319,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>libhl.lib;dxcompiler.lib</AdditionalDependencies>
+      <AdditionalDependencies>libhl.lib;dxcompiler.lib;D3D12.lib;dxgi.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseAll|x64'">
@@ -329,7 +329,7 @@
       </PrecompiledHeader>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>HL_AFTERMATH;NDEBUG;_WINDOWS;_USRDLL;DIRECTX_EXPORTS;%(PreprocessorDefinitions);HL_AFTERMATH</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;DIRECTX_EXPORTS;%(PreprocessorDefinitions);HL_AFTERMATH</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard_C>stdc11</LanguageStandard_C>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
@@ -342,7 +342,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>libhl.lib;dxcompiler.lib</AdditionalDependencies>
+      <AdditionalDependencies>libhl.lib;dxcompiler.lib;D3D12.lib;dxgi.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/libs/directx/dx12.vcxproj
+++ b/libs/directx/dx12.vcxproj
@@ -196,7 +196,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <OutputFile>../../$(Configuration)/$(TargetName).hdll</OutputFile>
-      <AdditionalDependencies>libhl.lib;dxcompiler.lib</AdditionalDependencies>
+      <AdditionalDependencies>libhl.lib;dxcompiler.lib;D3D12.lib;dxgi.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugAll|Win32'">
@@ -213,7 +213,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <OutputFile>../../$(Configuration)/$(TargetName).hdll</OutputFile>
-      <AdditionalDependencies>libhl.lib;dxcompiler.lib</AdditionalDependencies>
+      <AdditionalDependencies>libhl.lib;dxcompiler.lib;D3D12.lib;dxgi.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -270,7 +270,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <OutputFile>../../$(Configuration)/$(TargetName).hdll</OutputFile>
-      <AdditionalDependencies>libhl.lib;dxcompiler.lib</AdditionalDependencies>
+      <AdditionalDependencies>libhl.lib;dxcompiler.lib;D3D12.lib;dxgi.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseAll|Win32'">
@@ -295,7 +295,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <OutputFile>../../$(Configuration)/$(TargetName).hdll</OutputFile>
-      <AdditionalDependencies>libhl.lib;dxcompiler.lib</AdditionalDependencies>
+      <AdditionalDependencies>libhl.lib;dxcompiler.lib;D3D12.lib;dxgi.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -329,7 +329,7 @@
       </PrecompiledHeader>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;DIRECTX_EXPORTS;%(PreprocessorDefinitions);HL_AFTERMATH</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HL_AFTERMATH;NDEBUG;_WINDOWS;_USRDLL;DIRECTX_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard_C>stdc11</LanguageStandard_C>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>


### PR DESCRIPTION
Remove HL_STREAMLINE and sl.interposer.lib. dx12 now has no knowledge of Streamline
Statically linking D3D12.lib and dxgi.lib in all scenarios
Add functions to upgrade device and factory, and set back proxy ones (via set_device / set_factory)
Separate create command queue from device creation