### PR TITLE
JIT: emit float CMOV as branch-around-mov instead of flag-preserving blend

### DIFF
--- a/other/tests/Test_cmov.hx
+++ b/other/tests/Test_cmov.hx
@@ -1,0 +1,69 @@
+// Targets the float CMOV path (PHI_COND -> float conditional select) that the
+// jit_x86_64.c change rewrites from a flag-preserving branchless blend into a
+// branch-around-a-move. Every case below produces a float phi on a conditional
+// edge, in register and (under pressure) spilled forms, plus a following use of
+// the SAME compare so the shared-flags invariant is exercised.
+class Test_cmov {
+
+	// simple float ternary: out := cond ? a : b  (both in regs)
+	static function selReg( c : Bool, a : Float, b : Float ) : Float {
+		return c ? a : b;
+	}
+
+	// float32 variant (M_F32 path in the encoder)
+	static function selF32( c : Bool, a : Single, b : Single ) : Single {
+		return c ? a : b;
+	}
+
+	// the compare result is consumed TWICE: once by the float select, once by a
+	// following branch. This is the exact shape that forced pushfq/popfq before.
+	static function sharedCompare( x : Float, a : Float, b : Float ) : Float {
+		var pick = (x > 0.5) ? a : b;   // float select on (x>0.5)
+		if( x > 0.5 )                    // same comparison drives a real branch
+			pick += 1000.0;
+		return pick;
+	}
+
+	// heavy register pressure so the select operand is a SPILLED (memory) float,
+	// exercising the !IS_REG(e->a) branch (the old "ANDNPD requires aligned addr").
+	static function selSpilled( c : Bool, seed : Float ) : Float {
+		var f0=seed+0.0, f1=seed+1.0, f2=seed+2.0, f3=seed+3.0, f4=seed+4.0;
+		var f5=seed+5.0, f6=seed+6.0, f7=seed+7.0, f8=seed+8.0, f9=seed+9.0;
+		var f10=seed+10.,f11=seed+11.,f12=seed+12.,f13=seed+13.,f14=seed+14.;
+		var f15=seed+15.,f16=seed+16.,f17=seed+17.,f18=seed+18.,f19=seed+19.;
+		// a conditional pick of two cold spilled floats
+		var pick = c ? f17 : f3;
+		return f0+f1+f2+f3+f4+f5+f6+f7+f8+f9+f10+f11+f12+f13+f14
+			+f15+f16+f17+f18+f19 + pick*1000.0;
+	}
+
+	// selects inside a loop, alternating condition, to hit both taken/not-taken
+	static function loopSel( n : Int ) : Float {
+		var acc = 0.0;
+		for( i in 0...n ) {
+			var c = (i & 1) == 0;
+			var v = c ? (i * 1.5) : (i * -2.25);
+			acc += v;
+		}
+		return acc;
+	}
+
+	static function fmt( f : Float ) return Math.round(f*10000)/10000;
+
+	static function main() {
+		trace("=== start ===");
+		for( c in [true,false] )
+			for( a in [1.5, -3.25] )
+				for( b in [10.0, -0.5] )
+					trace("selReg", c, a, b, fmt(selReg(c,a,b)));
+		for( c in [true,false] )
+			trace("selF32", c, fmt(selF32(c, 2.5, -7.5)));
+		for( x in [0.0, 0.5, 0.6, 1.0, -1.0] )
+			trace("sharedCompare", x, fmt(sharedCompare(x, 3.0, 4.0)));
+		for( c in [true,false] )
+			trace("selSpilled", c, fmt(selSpilled(c, 0.5)));
+		for( n in [0,1,2,5,10] )
+			trace("loopSel", n, fmt(loopSel(n)));
+		trace("=== done ===");
+	}
+}

--- a/src/jit_x86_64.c
+++ b/src/jit_x86_64.c
@@ -1707,47 +1707,11 @@ void hl_codegen_function( jit_ctx *jit ) {
 				int cond = get_cond_jump(ctx);
 				if( !IS_REG(out) ) jit_assert();
 				if( IS_FLOAT(e->mode) ) {
-					EMIT(PUSHFQ,UNUSED,UNUSED,M_PTR);
-					// create a mask in RTMP to be used for xmm
-					emit_cset(ctx,RTMP,cond);
-					EMIT(MOVZX8,RTMP,RTMP,M_PTR);
-					EMIT(NEG,RTMP,UNUSED,M_PTR);
-					// do dst := (mask & src) | (dst & ~mask)
-					ereg tmp = get_tmp(M_F64);
-					EMIT(MOVQ,tmp,RTMP,M_PTR);
-					if( cpu_avx ) {
-						emit_vex(ctx,ANDNPD,out,tmp,out); // out := ~mask & out
-						if( !IS_REG(e->a) ) {
-							ereg tmp2 = out == MMX(0) ? MMX(1) : MMX(0);
-							EMIT(SUB,R(RSP),MK_CONST(8),M_PTR);
-							EMIT(MOVSD,REG_PTR(R(RSP)),tmp2,M_F64);
-							EMIT(e->mode == M_F32 ? MOVSS : MOVSD,tmp2,e->a,e->mode);
-							emit_vex(ctx,ANDPD,tmp,tmp,tmp2); // tmp := mask & src
-							EMIT(MOVSD,tmp2,REG_PTR(R(RSP)),M_PTR);
-							EMIT(ADD,R(RSP),MK_CONST(8),M_PTR);
-						} else
-							emit_vex(ctx,ANDPD,tmp,tmp,e->a); // tmp := mask & src
-						emit_vex(ctx,ORPD,out,out,tmp);
-						EMIT(POPFQ,UNUSED,UNUSED,M_PTR);
-						break;
-					}
-					EMIT(ANDNPD,tmp,out,M_F64);
-					EMIT(MOVQ,out,RTMP,M_PTR);
-					if( !IS_REG(e->a) ) {
-						// ANDNPD requires aligned address !
-						ereg tmp2 = out == MMX(0) ? MMX(1) : MMX(0);
-						EMIT(SUB,R(RSP),MK_CONST(8),M_PTR);
-						EMIT(MOVSD,REG_PTR(R(RSP)),tmp2,M_F64);
-						EMIT(e->mode == M_F32 ? MOVSS : MOVSD,tmp2,e->a,e->mode);
-						EMIT(ANDPD,out,tmp2,M_F64);
-						EMIT(ORPD,out,tmp,M_F64);
-						EMIT(MOVSD,tmp2,REG_PTR(R(RSP)),M_PTR);
-						EMIT(ADD,R(RSP),MK_CONST(8),M_PTR);
-					} else {
-						EMIT(ANDPD,out,e->a,M_F64);
-						EMIT(ORPD,out,tmp,M_F64);
-					}
-					EMIT(POPFQ,UNUSED,UNUSED,M_PTR);
+					// no cmovcc for XMM: branch around a mov. The jcc reads but
+					// doesn't clobber EFLAGS, so a following JCOND sharing this CMP still works.
+					int jskip = jump_near(ctx, cond ^ 1);
+					emit_mov(ctx, out, e->a, e->mode);
+					patch_jump_near(ctx, jskip);
 				} else if( IS_REG(e->a) ) {
 					emit_cmov(ctx,out,e->a,cond,M_PTR);					
 				} else {


### PR DESCRIPTION
## Claude summary

> The float conditional-move (used to resolve a float phi on a conditional edge, e.g. a `cond ? a : b` float ternary) had no cmovcc for XMM, so it was lowered to a branchless mask blend (setcc/neg/movq/andnpd/andpd/orpd). That arithmetic clobbers EFLAGS, but a following JCOND re-derives its condition from the same shared CMP (get_cond_jump skips over CMOV), so the blend had to be bracketed with pushfq/popfq to keep the flags alive. popfq is heavily microcoded and serializes the pipeline: on a hot particle-update loop it dominated the Core-Bound cycles (VTune: ~44% Serializing Operations).

> Emit a short jcc that skips a plain mov instead. A jcc reads EFLAGS but never writes them, so the shared compare survives naturally for the trailing JCOND. This drops the pushfq/popfq, the whole blend, and the stack spill the memory-operand path needed for ANDPD alignment. It mirrors the existing float CXCHG lowering right below this case. ~6% faster on the particle benchmark; output verified identical against the previous codegen (see Test_cmov.hx).

I'll be honest I didn't get any of that

## How I got here
I was benchmarking hide Emitter particles with VTune and noticed a lot of time was spend on a simple if(myenum != VZero) which should have been cheap.
The time was showing up under "Serializing Operations" which seemed weird, I'd have expected either cache miss on resolving the enum or branch prediction issues.
Feeding the assembly code to Claude led to this:

> Haxe: if (def.dampen != hrt.prefab.fx.Value.VZero) { ... } in the per-particle loop (hrt.prefab.fx.ParticleInstance). def.dampen is loop-invariant — same for every particle, every frame until the effect is edited. The != VZero test, a null check, and a switch(enumIndex val) are all being re-evaluated per particle.

> The single comparison result is consumed twice:
> As a branchless float select — setz → movzx/neg → movq xmm, then vandnpd/vandpd/vorpd to blend two doubles (resolving the dampen ternary).
> As a real branch — the terminal jz <Block 122> that skips the whole if block.

> Because the blend arithmetic (and sub rsp,8 / add rsp,8 register spills) clobbers EFLAGS, the encoder brackets it with pushfq / popfq to keep ZF alive for the jz. There are TWO such pairs on this line. popfq is heavily microcoded and drains the pipeline → this is the 43.6% Serializing Operations. All operands are scalar movsd → explains the 12.3% vectorization.

## Results
Noticeable improvements in my particles benchmark.
Tested the new hl.exe with the SpaceCraft and Farever codebases and didn't notice any issue.
