### PR TITLE
Make macOS HDLLs relocatable

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -13,6 +13,16 @@ function(set_as_hdll target)
         OUTPUT_NAME ${target}
         SUFFIX ${HDLL_SUFFIX}
     )
+    if (APPLE)
+        # Keep macOS HDLLs relocatable in both the build and install trees.
+        # CMake otherwise embeds the absolute build/bin directory because the
+        # target links libhl. Copying such an HDLL beside another compatible
+        # VM can silently load HashLink's build-tree libhl as a second runtime.
+        set_target_properties(${target}.hdll PROPERTIES
+            BUILD_WITH_INSTALL_RPATH TRUE
+            INSTALL_RPATH "@loader_path"
+        )
+    endif()
     if (NOT MSVC AND NOT APPLE)
         target_link_options(${target}.hdll PRIVATE "-Wl,--no-undefined")
     endif()


### PR DESCRIPTION
## Problem

CMake gives macOS HDLL build artifacts an absolute LC_RPATH pointing at the build output directory because they link against libhl. Copying an HDLL such as sdl.hdll into another compatible VM project can therefore load the HashLink build-tree libhl as a second runtime instead of the host VM runtime. Objects crossing those two runtime/GC instances then fail in misleading places; the reproduced SDL path created its OpenGL shader successfully and crashed while boxing the shader ID through the other libhl allocator.

## Fix

Use @loader_path as the build and install rpath for Apple HDLL targets. HashLink build-tree and flat-install layouts already place libhl beside their HDLLs, while copied HDLLs can resolve the compatible runtime supplied by their host application without retaining an absolute path to the machine that built them.

## Validation

- Built sdl.hdll on macOS arm64 against SDL 3.4.10.
- Verified its only LC_RPATH is @loader_path in both build and cmake --install outputs.
- Ran the copied build artifact in an Apple Silicon compatible VM through SDL window creation, OpenGL shader compilation, Main.main(), and hxd.App.init().
- Verified the ordinary HashLink flat install still places libhl beside sdl.hdll.