### PR TITLE
Link Apple's OpenGL framework on macOS

### DIFF
--- a/libs/sdl/CMakeLists.txt
+++ b/libs/sdl/CMakeLists.txt
@@ -62,9 +62,19 @@ if((APPLE OR UNIX) AND NOT ANDROID)
         PRIVATE
         ${OPENGL_INCLUDE_DIR}
     )
+    if(APPLE)
+        # Only Apple's framework can serve the CGL context SDL creates.
+        # find_package(OpenGL) picks a Homebrew Mesa libGL ahead of it when
+        # CMAKE_FIND_FRAMEWORK is LAST; that links fine and then every gl*
+        # call returns 0/NULL.
+        find_library(HL_APPLE_OPENGL_FRAMEWORK OpenGL REQUIRED)
+        set(HL_SDL_GL_LIBRARY ${HL_APPLE_OPENGL_FRAMEWORK})
+    else()
+        set(HL_SDL_GL_LIBRARY ${OPENGL_gl_LIBRARY})
+    endif()
     target_link_libraries(sdl.hdll
         libhl
-        ${OPENGL_gl_LIBRARY}
+        ${HL_SDL_GL_LIBRARY}
     )
 endif()
 


### PR DESCRIPTION
`find_package(OpenGL)` reports a Homebrew Mesa `libGL` ahead of the framework when `CMAKE_FIND_FRAMEWORK` is `LAST`. `sdl.hdll` then links and loads fine, and every `gl*` call goes to a Mesa with no current context.

Symptoms: `glGetString` returns NULL, `glCreateShader` returns 0. `Window.testGL()` checks neither, so the first visible failure is a segfault in `glShaderSource` on a null shader.

Only Apple's framework can serve the CGL context SDL creates, so ask for it by name.

Verified on macOS arm64 (SDL 3.4.16), configuring with `-DCMAKE_FIND_FRAMEWORK=LAST` and Mesa installed:

- before: `sdl.hdll` links `/opt/homebrew/opt/mesa/lib/libGL.1.dylib`; `GL_VERSION` is null, `createShader` null
- after: links `OpenGL.framework`; `GL_VERSION` = `4.1 Metal - 90.5`, `GLSL` = `4.10`, `createShader` = 1, Heaps/HaxeUI app renders