### PR TITLE
[ui] Added isFolder to ui_choose_file options

### DIFF
--- a/libs/ui/CMakeLists.txt
+++ b/libs/ui/CMakeLists.txt
@@ -1,7 +1,8 @@
 add_library(ui.hdll ui_stub.c)
 
 if(WIN32)
-    set_target_properties(ui.hdll PROPERTIES SOURCES ui_win.c)
+    set_target_properties(ui.hdll PROPERTIES SOURCES "ui_win.c;utils.cpp")
+	target_link_libraries(ui.hdll Shell32 Ole32)
 endif()
 
 set_as_hdll(ui)

--- a/libs/ui/ui.vcxproj
+++ b/libs/ui/ui.vcxproj
@@ -123,7 +123,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>libhl.lib;user32.lib;gdi32.lib;comdlg32.lib</AdditionalDependencies>
+      <AdditionalDependencies>libhl.lib;user32.lib;gdi32.lib;comdlg32.lib;Shell32.lib;Ole32.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -172,11 +172,12 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>libhl.lib;user32.lib;gdi32.lib;comdlg32.lib</AdditionalDependencies>
+      <AdditionalDependencies>libhl.lib;user32.lib;gdi32.lib;comdlg32.lib;Shell32.lib;Ole32.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="ui_win.c" />
+    <ClCompile Include="utils.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/libs/ui/ui.vcxproj.filters
+++ b/libs/ui/ui.vcxproj.filters
@@ -2,5 +2,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="ui_win.c" />
+    <ClCompile Include="utils.cpp" />
   </ItemGroup>
 </Project>

--- a/libs/ui/ui_win.c
+++ b/libs/ui/ui_win.c
@@ -282,11 +282,14 @@ HL_PRIM void HL_NAME(ui_close_console)() {
 	FreeConsole();
 }
 
+// declared in utils.cpp, because COM objects don't play nicely with pure C code
+bool chooseFolder(const wchar_t* title, const wchar_t* defaultFolder, wchar_t* outBuffer);
 
 HL_PRIM vbyte *HL_NAME(ui_choose_file)( bool forSave, vdynamic *options ) {
 	wref *win = (wref*)hl_dyn_getp(options,hl_hash_utf8("window"), &hlt_abstract);
 	varray *filters = (varray*)hl_dyn_getp(options,hl_hash_utf8("filters"),&hlt_array);
 	wchar_t *fileName = (wchar_t*)hl_dyn_getp(options,hl_hash_utf8("fileName"),&hlt_bytes);
+	bool isFolder = (bool)hl_dyn_geti(options,hl_hash_utf8("isFolder"),&hlt_bool);
 	OPENFILENAME op;
 	wchar_t filterStr[1024];
 	wchar_t outputFile[1024] = {0};
@@ -318,9 +321,14 @@ HL_PRIM vbyte *HL_NAME(ui_choose_file)( bool forSave, vdynamic *options ) {
 		if( !GetSaveFileName(&op) )
 			return NULL;
 	} else {
-		op.Flags |= OFN_CREATEPROMPT;
-		if( !GetOpenFileName(&op) )
-			return NULL;
+		if (!isFolder) {
+			op.Flags |= OFN_CREATEPROMPT;
+			if( !GetOpenFileName(&op) )
+				return NULL;
+		} else {
+			if (!chooseFolder(op.lpstrTitle, op.lpstrInitialDir, outputFile))
+				return NULL;
+		}
 	}
 	return hl_copy_bytes((vbyte*)outputFile, (int)(wcslen(outputFile)+1)*2);
 }

--- a/libs/ui/utils.cpp
+++ b/libs/ui/utils.cpp
@@ -1,0 +1,55 @@
+/* Functions that need cpp support for ui_win.c */
+
+#include <shobjidl.h>
+#include <windows.h>
+
+/** 
+ * Returns false if an error happened while choosing the folder, else returns true and outBuffer
+ * contains the file path
+ * **/
+extern "C" bool chooseFolder(const wchar_t* title, const wchar_t* defaultFolder, wchar_t* outBuffer) {
+	IFileDialog* ifd;
+	HRESULT hr = CoCreateInstance(CLSID_FileOpenDialog,
+		NULL,
+		CLSCTX_INPROC_SERVER,
+		IID_PPV_ARGS(&ifd));
+	if (!SUCCEEDED(hr))
+		return false;
+
+    if (defaultFolder != nullptr) {
+        IShellItem* folder;
+        hr = SHCreateItemFromParsingName(defaultFolder, nullptr, IID_PPV_ARGS(&folder));
+        if (SUCCEEDED(hr)) {
+            ifd->SetDefaultFolder(folder);
+            folder->Release();
+        }
+    }
+
+	ifd->SetOptions(FOS_PICKFOLDERS | FOS_FORCEFILESYSTEM);
+	ifd->SetTitle(title);
+
+    hr = ifd->Show(GetActiveWindow());
+    bool success = false;
+    if (SUCCEEDED(hr))
+    {
+        IShellItem* item;
+        hr = ifd->GetResult(&item);
+        if (SUCCEEDED(hr))
+        {
+            wchar_t* wname = nullptr;
+
+            if (SUCCEEDED(item->GetDisplayName(SIGDN_FILESYSPATH, &wname)))
+            {
+                memcpy(outBuffer, wname, (int)(wcslen(wname) + 1) * 2);
+                CoTaskMemFree(wname);
+                success = true;
+            }
+
+            item->Release();
+        }
+    }
+
+    ifd->Release();
+
+    return success;
+}


### PR DESCRIPTION
This add the ability to specify that we want a folder instead of a file when prompting the user with the native choose file dialog.

This add a new utils.cpp file, because having a prompt to choose a folder using windows filebrowser need to use a COM based interface, and these are very tricky to use in pure C. Using C++ allows us to use the api as intended, and we make a simple wrapper around that that can be then called from the C side.