### PR TITLE
mysql.hdll: use-after-free and double free when mysql_real_connect fails

### DIFF
--- a/libs/mysql/mysql.c
+++ b/libs/mysql/mysql.c
@@ -352,6 +352,7 @@ HL_PRIM connection *HL_NAME(connect_wrap)( cnx_params *p ) {
 		hl_buffer_cstr(b, "Failed to connect to mysql server : ");
 		hl_buffer_cstr(b,mysql_error(c->c));
 		mysql_close(c->c);
+		c->c = NULL;
 		hl_throw_buffer(b);
 	}
 	return c;


### PR DESCRIPTION
connect_wrap in libs/mysql/mysql.c arms a GC finalizer on the connection object before attempting the connection, and on failure frees the underlying MYSQL* without clearing the pointer. The object survives as garbage with a dangling c->c; when the GC later runs its finalizer, close_wrap reads from and then frees that already-freed block.

The code
libs/mysql/mysql.c:345:

HL_PRIM connection *HL_NAME(connect_wrap)( cnx_params *p ) {
    connection *c = (connection*)hl_gc_alloc_finalizer(sizeof(connection));
    memset(c,0,sizeof(connection));
    c->free = HL_NAME(close_wrap);      // finalizer armed here
    c->c = mysql_init(NULL);            // malloc'd MYSQL* (my_api.c:97)
    if( mysql_real_connect(c->c,p->host,p->user,p->pass,NULL,p->port,p->socket,0) == NULL ) {
        hl_buffer *b = hl_alloc_buffer();
        hl_buffer_cstr(b, "Failed to connect to mysql server : ");
        hl_buffer_cstr(b,mysql_error(c->c));
        mysql_close(c->c);              // free(m) -- c->c is NOT nulled
        hl_throw_buffer(b);             // throws; c survives as garbage
    }
    return c;
}
close_wrap is itself correct and already guards for this:

HL_PRIM void HL_NAME(close_wrap)( connection *c ) {
    if( c->c ) {
        mp_close(c->c);
        c->c = NULL;
    }
}
so a failed connect is the only path that can leave a finalizable object holding a freed pointer. On the success path the finalizer is fine.

When the GC collects the orphaned object it calls close_wrap -> mp_close -> myp_close, which reads m->s out of the freed struct (psock_close(m->s), my_api.c:92), and mysql_close then frees m->packet.buf, m->infos.server_version and m a second time -- three double frees, using pointers read from freed memory.

Impact
The damaged free list surfaces later, at an unrelated allocation, as glibc's corrupted double-linked list followed by SIGSEGV. Because the crash site is nowhere near the cause, this is very hard to attribute -- we initially spent considerable time investigating our TLS listeners.

Any application that retries a connection while the database is unreachable orphans one object per failed attempt. In our case a health endpoint reconnecting every 2 seconds during a MySQL outage made it reliably fatal.

Reproduction
Run any HashLink program that repeatedly attempts sys.db.Mysql.connect while the server is unreachable, then allow a major GC. Under ASan (built with DEBUG=1, src/gc.o compiled -fno-sanitize=address, and ASAN_OPTIONS=replace_intrin=0 -- both needed so the conservative collector does not trip the sanitizer first):

==1==ERROR: AddressSanitizer: heap-use-after-free
READ of size 4 at 0x619000007380 thread T0
    #0 myp_close            libs/mysql/my_api.c:92
    #1 mp_close             libs/mysql/my_api.c:440
    #2 mysql_close_wrap     libs/mysql/mysql.c:297
    #3 gc_call_finalizers   src/allocator.c:516
    #4 gc_allocator_after_mark src/allocator.c:597
    #5 gc_mark              src/gc.c:858
freed by thread T0 here:
    #1 mysql_connect_wrap   libs/mysql/mysql.c:354
previously allocated by thread T0 here:
    #1 mp_init              libs/mysql/my_api.c:97
    #2 mysql_connect_wrap   libs/mysql/mysql.c:349
Fix
--- a/libs/mysql/mysql.c
+++ b/libs/mysql/mysql.c
@@ -351,6 +351,7 @@ HL_PRIM connection *HL_NAME(connect_wrap)( cnx_params *p ) {
 		hl_buffer *b = hl_alloc_buffer();
 		hl_buffer_cstr(b, "Failed to connect to mysql server : ");
 		hl_buffer_cstr(b,mysql_error(c->c));
 		mysql_close(c->c);
+		c->c = NULL;
 		hl_throw_buffer(b);
 	}
 	return c;
Verified with an otherwise identical A/B: unpatched, the sanitizer reports the use-after-free and the process dies within the first kill/restore cycle (reproduced on 2 of 2 runs); patched, three full cycles complete with no report and the process still running.

Aside: ASAN_DISABLE is a no-op under GCC/Clang
Not part of this bug, but found while chasing it. src/gc.c annotates gc_mark_stack with ASAN_DISABLE, but src/hl.h only defines that macro to anything real under:

#if defined(HL_VCC) && defined(__SANITIZE_ADDRESS__)
#	define ASAN_DISABLE __declspec(no_sanitize_address)
#else
#	define ASAN_DISABLE
#endif
Under GCC/Clang it expands to nothing, so the annotation silently has no effect and the conservative stack scan trips ASan immediately. A __attribute__((no_sanitize_address)) branch would make the existing annotation work as intended -- though note that gc_save_context's memcpy still needs ASAN_OPTIONS=replace_intrin=0, since ASan's libc interceptors are installed process-wide regardless of how a translation unit was compiled. Happy to file that separately if useful.